### PR TITLE
try to change our check to skip_on_ci()

### DIFF
--- a/tests/testthat/test-create_analytic_cohort.R
+++ b/tests/testthat/test-create_analytic_cohort.R
@@ -2,7 +2,7 @@
 # from create_analytic_cohort
 test_that("correct number of objects returned from create cohort", {
   # exit if user doesn't have synapser, a log in, or access to data.
-  genieBPC:::check_synapse_login()
+  skip_on_ci()
 
   # run here to avoid having to run within each test
   nsclc_data <- pull_data_synapse("NSCLC", version = "1.1-consortium")
@@ -57,7 +57,7 @@ test_that("pull data synapse object is missing", {
 })
 
 test_that("correct cohort returned from create cohort", {
-  genieBPC:::check_synapse_login()
+  skip_on_ci()
 
   test1 <- create_analytic_cohort(
     cohort = "NSCLC",
@@ -82,7 +82,7 @@ test_that("correct cohort returned from create cohort", {
 })
 
 test_that("cohort and data_synapse", {
-  genieBPC:::check_synapse_login()
+  skip_on_ci()
 
   # no diagnosis criteria specified
   # expect that the first index cancer is returned without any other
@@ -113,7 +113,7 @@ test_that("cohort and data_synapse", {
 })
 
 test_that("index_ca_seq", {
-  genieBPC:::check_synapse_login()
+  skip_on_ci()
 
   # first and second index cancer is specified
   # if patient only has 1 index cancer, it should be returned
@@ -161,7 +161,7 @@ test_that("index_ca_seq", {
 })
 
 test_that("institution", {
-  genieBPC:::check_synapse_login()
+  skip_on_ci()
 
   # institution is specified and correct institution is returned
   test_1a <- create_analytic_cohort(
@@ -209,7 +209,7 @@ test_that("institution", {
 })
 
 test_that("stage_dx", {
-  genieBPC:::check_synapse_login()
+  skip_on_ci()
 
   # stage dx is specified and correct stage is returned
   test_1a <- create_analytic_cohort(
@@ -250,7 +250,7 @@ test_that("stage_dx", {
 })
 
 test_that("histology", {
-  genieBPC:::check_synapse_login()
+  skip_on_ci()
 
   # no histology is specified, call are returned
   test0a <- create_analytic_cohort(
@@ -338,7 +338,7 @@ test_that("histology", {
 })
 
 test_that("no regimen specified", {
-  genieBPC:::check_synapse_login()
+  skip_on_ci()
 
   # all regimens are returned
   test_1a <- create_analytic_cohort(
@@ -361,7 +361,7 @@ test_that("no regimen specified", {
 })
 
 test_that("drug regimen specified, order not specified", {
-  genieBPC:::check_synapse_login()
+  skip_on_ci()
 
   # one drug regimen specified, but order not specified
   test_1a <- create_analytic_cohort(
@@ -457,7 +457,7 @@ test_that("drug regimen specified, order not specified", {
 })
 
 test_that("drug regimen specified, order specified to be within cancer", {
-  genieBPC:::check_synapse_login()
+  skip_on_ci()
 
   # regimen of a certain number but drug name not specified
   # all patients whose first drug after diagnosis was carbo pem
@@ -601,7 +601,7 @@ test_that("drug regimen specified, order specified to be within cancer", {
 
 test_that("exact drug regimen specified,
           order specified to be within regimen", {
-  genieBPC:::check_synapse_login()
+  skip_on_ci()
 
   # single regimen specified, want first time that regimen
   # was given for all cancers
@@ -695,7 +695,7 @@ test_that("exact drug regimen specified,
 test_that("containing drug regimen specified,
           order specified to be within regimen", {
 
-  genieBPC:::check_synapse_login()
+  skip_on_ci()
 
   # specify regimen type to be containing (default is exact,
   # which is what is implemented in the above)
@@ -748,7 +748,7 @@ test_that("containing drug regimen specified,
 })
 
 test_that("regimen_type", {
-  genieBPC:::check_synapse_login()
+  skip_on_ci()
 
   # invalid value provided for regimen_type
   expect_error(create_analytic_cohort(cohort = "NSCLC",
@@ -763,7 +763,7 @@ test_that("regimen_type", {
 })
 
 test_that("regimen_order", {
-  genieBPC:::check_synapse_login()
+  skip_on_ci()
 
   # character value provided for regimen_order
   expect_error(create_analytic_cohort(cohort = "BrCa",
@@ -772,7 +772,7 @@ test_that("regimen_order", {
 })
 
 test_that("regimen_order_type", {
-  genieBPC:::check_synapse_login()
+  skip_on_ci()
 
   # invalid value provided for regimen_order_type
   expect_error(create_analytic_cohort(cohort = "BrCa",
@@ -794,7 +794,7 @@ test_that("regimen_order_type", {
 })
 
 test_that("No patients met criteria", {
-  genieBPC:::check_synapse_login()
+  skip_on_ci()
 
   expect_message(create_analytic_cohort(
     cohort = "NSCLC",

--- a/tests/testthat/test-drug_regimen_sunburst.R
+++ b/tests/testthat/test-drug_regimen_sunburst.R
@@ -1,6 +1,6 @@
 test_that("Test class and length of list for sunburst plot", {
   # exit if user doesn't have synapser, a log in, or access to data.
-  genieBPC:::check_synapse_login()
+  skip_on_ci()
 
   # run here to avoid having to run within each test
   nsclc_data <- pull_data_synapse("NSCLC", version = "1.1-consortium")
@@ -27,7 +27,7 @@ test_that("Test class and length of list for sunburst plot", {
 
 
 test_that("Test class and length of list for elements of sunburst data frame", {
-  genieBPC:::check_synapse_login()
+  skip_on_ci()
 
   expect_equal(length(plot1$treatment_history), 2)
   expect_equal(class(plot1$treatment_history),
@@ -37,7 +37,7 @@ test_that("Test class and length of list for elements of sunburst data frame", {
 
 test_that("Test class and length of list for elements
           of sunburst plotly element", {
-  genieBPC:::check_synapse_login()
+  skip_on_ci()
 
   expect_equal(length(plot1$sunburst_plot), 8)
   expect_equal(class(plot1$sunburst_plot), c("sunburst","htmlwidget"))
@@ -45,7 +45,7 @@ test_that("Test class and length of list for elements
 
 
 test_that("Test something is returned", {
-  genieBPC:::check_synapse_login()
+  skip_on_ci()
 
   expect_error(plot1,NA)
 })
@@ -75,7 +75,7 @@ test_that("data_cohort parameter", {
 })
 
 test_that("lines of tx specified", {
-  genieBPC:::check_synapse_login()
+  skip_on_ci()
 
   # line of therapy isn't specified, select all
   test1a <- drug_regimen_sunburst(data_synapse = nsclc_data,

--- a/tests/testthat/test-fetch_samples.R
+++ b/tests/testthat/test-fetch_samples.R
@@ -1,6 +1,6 @@
 test_pull_data <- function(){
   # exit if user doesn't have synapser, a log in, or access to data.
-  genieBPC:::check_synapse_login()
+  skip_on_ci()
 
   # run here to avoid having to run within each test
   nsclc_data <- pull_data_synapse("NSCLC", version = "1.1-consortium")
@@ -28,7 +28,7 @@ test_that("missing input parameters", {
 })
 
 test_that("function returns correct number of samples", {
-  genieBPC:::check_synapse_login()
+  skip_on_ci()
 
   # NSCLC #
   ### all samples ###

--- a/tests/testthat/test-pull_data_synapse.R
+++ b/tests/testthat/test-pull_data_synapse.R
@@ -4,7 +4,7 @@ test_that("Missing cohort parameter", {
 
 test_that("Test class and length of list for NSCLC", {
   # exit if user doesn't have synapser, a log in, or access to data.
-  genieBPC:::check_synapse_login()
+  skip_on_ci()
 
   # run at top to avoid having to run within each test
   nsclc_data <- pull_data_synapse("NSCLC", version = "1.1-consortium")
@@ -21,14 +21,14 @@ test_that("Test class and length of list for NSCLC", {
 #
 
 test_that("Test class length of list for CRC", {
-  genieBPC:::check_synapse_login()
+  skip_on_ci()
 
   expect_equal(length(crc_data), 12)
   expect_equal(class(crc_data), "list")
 })
 
 test_that("Case sensitivity of cohort", {
-  genieBPC:::check_synapse_login()
+  skip_on_ci()
 
   lung1 <- pull_data_synapse("NSCLC", version = "1.1-consortium")
   lung2 <- pull_data_synapse("nsclc", version = "1.1-consortium")
@@ -45,7 +45,7 @@ test_that("Misspecified cohort or version", {
 })
 
 test_that("Number of columns and rows for each NSCLC dataset", {
-  genieBPC:::check_synapse_login()
+  skip_on_ci()
 
   col_length <- vapply(nsclc_data, length, FUN.VALUE = numeric(1))
   row_length <- vapply(nsclc_data, nrow, FUN.VALUE = numeric(1))
@@ -57,7 +57,7 @@ test_that("Number of columns and rows for each NSCLC dataset", {
 })
 
 test_that("Number of columns and rows for each CRC dataset", {
-  genieBPC:::check_synapse_login()
+  skip_on_ci()
 
   col_length <- vapply(crc_data, length, FUN.VALUE = numeric(1))
   row_length <- vapply(crc_data, nrow, FUN.VALUE = numeric(1))
@@ -70,7 +70,7 @@ test_that("Number of columns and rows for each CRC dataset", {
 })
 
 test_that("Test synget equals pulldata synapse", {
-  genieBPC:::check_synapse_login()
+  skip_on_ci()
 
   ptchar_nsclc_synget <- read.csv(
     synapser::synGet("syn22418979")$path) # version 1.1-consortium

--- a/tests/testthat/test-select_unique_ngs.R
+++ b/tests/testthat/test-select_unique_ngs.R
@@ -29,7 +29,7 @@ test_that("sample_type", {
 
 test_that("function returns unique sample for each record", {
   # exit if user doesn't have synapser, a log in, or access to data.
-  genieBPC:::check_synapse_login()
+  skip_on_ci()
 
   # run here to avoid having to run within each test
   nsclc_data <- pull_data_synapse("NSCLC", version = "1.1-consortium")

--- a/tests/testthat/test-synapse_version.R
+++ b/tests/testthat/test-synapse_version.R
@@ -1,5 +1,5 @@
 test_that("Testing synapse version", {
-  genieBPC:::check_synapse_login()
+  skip_on_ci()
 
   expect_equal(class(synapse_version(FALSE)),
                c("grouped_df", "tbl_df", "tbl", "data.frame"))


### PR DESCRIPTION
R Universe is still trying to run the tests and failing - maybe the skip() component of the check_synapse_login() function isn't working? Hard to test b/c we all have synapse and so the skip isn't triggered. Trying to skip on ci instead.

What changes are involved in this pull request? Is there a GitHub issue corresponding to this pull request? If so, please provide link.

Checklist
- [ ] Make sure all updates from master branch are pulled to branch issuing pull request
- [ ] Confirm package dependencies are installed by running `renv::install()`
- [ ] For bug corrections, check that unit test was added
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website
- [ ] Code coverage is suitable for any new functions/features. Review coverage with `covr::report()`. Before you run, begin in a fresh R session without any packages loaded and set `Sys.setenv(NOT_CRAN="true")`.
- [ ] R CMD Check runs without errors, warnings, and notes
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [ ] Document changes from this pull request in NEWS.md file
- [ ] Increment the version number using usethis::use_version(which = "dev")
- [ ] Approve and merge pull request
