### PR TITLE
Fix bug in drug regimen sunburst messaging, add tests for each cancer cohort

### DIFF
--- a/R/drug_regimen_sunburst.R
+++ b/R/drug_regimen_sunburst.R
@@ -72,15 +72,19 @@ drug_regimen_sunburst <- function(data_synapse,
   }
 
   # if the data_synapse parameter is a list but not the right list
-  if (is.null(names(data_synapse)) |
-    min(grepl(
-      "pt_char|ca_dx|ca_drugs|prissmm|cpt|cna|fusions|mutations",
-      names(data_synapse)
-    )) == 0) {
+  if (is.null(names(data_synapse))) {
     stop("Specify the list object returned from pull_data_synapse in the
          `data_synapse` parameter.")
+  } else if (sum(grepl(
+    "pt_char|ca_dx|ca_drugs|prissmm|cpt|cna|fusions|mutations",
+    names(data_synapse)
+  )) < 11) {
+    stop("Specify the list object returned from pull_data_synapse in the
+         `data_synapse` parameter containing the nested list with the dataframes:
+         pt_char, ca_dx_index, ca_dx_non_index, ca_drugs,
+         prissmm_imaging, prissmm_pathology, prissmm_md, cpt,
+         mutations_extended, fusions, and cna.")
   }
-
 
 
   # get the name of the cohort from the data_synapse object naming convention

--- a/tests/testthat/test-drug_regimen_sunburst.R
+++ b/tests/testthat/test-drug_regimen_sunburst.R
@@ -58,6 +58,51 @@ test_that("Test something is returned", {
   expect_error(plot1, NA)
 })
 
+test_that("Runs for all cohorts", {
+  skip_if_not(genieBPC:::.is_connected_to_genie())
+
+  # NSCLC
+  nsclc_v2_0 <- pull_data_synapse("NSCLC", "v2.0-public")
+  nsclc_cohort <- create_analytic_cohort(nsclc_v2_0$NSCLC_v2.0)
+  testthat::expect_no_error(drug_regimen_sunburst(nsclc_v2_0$NSCLC_v2.0, nsclc_cohort,
+                                                  max_n_regimens = 3))
+
+  # CRC
+  crc_v2_0 <- pull_data_synapse("CRC", "v2.0-public")
+  crc_cohort <- create_analytic_cohort(crc_v2_0$CRC_v2.0)
+  testthat::expect_no_error(drug_regimen_sunburst(crc_v2_0$CRC_v2.0,
+                                                  crc_cohort,
+                                                  max_n_regimens = 3))
+
+  # BrCa
+  brca_v1_2 <- pull_data_synapse("BrCa", "v1.2-consortium")
+  brca_cohort <- create_analytic_cohort(brca_v1_2$BrCa_v1.2)
+  testthat::expect_no_error(drug_regimen_sunburst(brca_v1_2$BrCa_v1.2,
+                                                  brca_cohort,
+                                                  max_n_regimens = 3))
+
+  # PANC
+  panc_v1_2 <- pull_data_synapse("PANC", "v1.2-consortium")
+  panc_cohort <- create_analytic_cohort(panc_v1_2$PANC_v1.2)
+  testthat::expect_no_error(drug_regimen_sunburst(panc_v1_2$PANC_v1.2,
+                                                  panc_cohort,
+                                                  max_n_regimens = 3))
+
+  # Prostate
+  prostate_v1_2 <- pull_data_synapse(cohort = "Prostate", version = "v1.2-consortium")
+  prostate_cohort <- create_analytic_cohort(data_synapse = prostate_v1_2$Prostate_v1.2)
+  testthat::expect_no_error(drug_regimen_sunburst(prostate_v1_2$Prostate_v1.2,
+                                                  prostate_cohort,
+                                                  max_n_regimens = 3))
+
+  # Bladder
+  bladder_v1_2 <- pull_data_synapse(cohort = "BLADDER", version = "v1.2-consortium")
+  bladder_cohort <- create_analytic_cohort(data_synapse = bladder_v1_2$BLADDER_v1.2)
+  testthat::expect_no_error(drug_regimen_sunburst(bladder_v1_2$BLADDER_v1.2,
+                                                  bladder_cohort,
+                                                  max_n_regimens = 3))
+})
+
 test_that("data_synapse parameter", {
   # missing the data_synapse input parameter
   expect_error(drug_regimen_sunburst())


### PR DESCRIPTION
- Updated error trigger in `drug_regimen_sunbrust` from flagging tumor markers and RT data as indicating that the wrong list was specified as the `data_synapse` parameter
- To do this, updated to instead check that each of the expected datasets are included (pt char, cancer diagnosis, PRISSMM datasets, genomics files)
- Added tests to make sure that the `drug_regimen_sunbrust` function runs for each cancer cohort to make sure no other similar issues arise

Is there a GitHub issue corresponding to this pull request? If so, please provide link.

Checklist for PR Reviewer
- [ ] Make sure all updates from master branch are pulled to branch issuing pull request
- [ ] Confirm package dependencies are installed by running `renv::install()`
- [ ] For bug corrections, check that unit test was added
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [ ] R CMD Check runs without errors, warnings, and notes
- [ ] Document changes from this pull request in `NEWS.md` file
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website. If there are errors returned, try running `pkgdown::build_site(new_process = FALSE)` for better error messaging.
- [ ] Code coverage is suitable for any new functions/features. Review coverage with `covr::report()`. Before you run, begin in a fresh R session without any packages loaded and set `Sys.setenv(NOT_CRAN="true")`.
- [ ] Increment the version number using `usethis::use_version(which = "dev")`
- [ ] Approve and merge pull request
