### PR TITLE
Update pull_data_synapse and synapse_version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: genieBPC
 Title: Project GENIE BioPharma Collaborative Data Processing Pipeline
-Version: 1.1.1
+Version: 1.1.1.9000
 Authors@R: 
     c(
     person(given = "Jessica A.",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # genieBPC (development)
 
+* Update 'cohort' parameter of `pull_data_synapse()` and `synapse_version()` to not be case-sensitive (#120)
+
+* `synapse_version(most_recent = TRUE)` now returns one row per cohort, as opposed to one row per cohort and type of data release (consortium vs public) (#128)
+
 * Update `drug_regimen_list` lookup table to include drug names by data release, as opposed to by cohort. It is possible that drug names were modified slightly across data releases (#132)
 
 # genieBPC 1.1.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# genieBPC (development)
+# genieBPC (development version)
 
 * Update 'cohort' parameter of `pull_data_synapse()` and `synapse_version()` to not be case-sensitive (#120)
 

--- a/R/pull_data_synapse.R
+++ b/R/pull_data_synapse.R
@@ -109,7 +109,7 @@ pull_data_synapse <- function(cohort = NULL, version = NULL,
   # get `cohort` ---
 
   # make cohort term not be case sensitive - will require update as new disease areas are added
-  cohort_case <- dplyr::case_when(
+  cohort <- dplyr::case_when(
     stringr::str_to_upper(cohort)=="NSCLC" |
       stringr::str_to_upper(cohort)=="NON-SMALL CELL LUNG CANCER" |
       stringr::str_to_upper(cohort)=="NON SMALL CELL LUNG CANCER" |
@@ -118,10 +118,14 @@ pull_data_synapse <- function(cohort = NULL, version = NULL,
     stringr::str_to_upper(cohort)=="BRCA" | stringr::str_to_upper(cohort)=="BREAST CANCER"~ "BrCa",
     stringr::str_to_upper(cohort)=="BLADDER" ~ "BLADDER",
     stringr::str_to_upper(cohort)=="PANC" | stringr::str_to_upper(cohort)=="PANCREAS" ~ "PANC",
-    stringr::str_to_upper(cohort)=="PROSTATE" ~ "Prostate"
+    stringr::str_to_upper(cohort)=="PROSTATE" ~ "Prostate",
+    # last condition to avoid error message:
+    # '`cohort` must be a single string, not a character `NA`.'
+    # when an NA is fed into arg_match below
+    TRUE ~ cohort
   )
 
-  select_cohort <- rlang::arg_match(cohort_case, c("NSCLC", "CRC", "BrCa", "BLADDER", "PANC", "Prostate"),
+  select_cohort <- rlang::arg_match(cohort, c("NSCLC", "CRC", "BrCa", "BLADDER", "PANC", "Prostate"),
     multiple = TRUE
   )
 

--- a/R/pull_data_synapse.R
+++ b/R/pull_data_synapse.R
@@ -9,7 +9,7 @@
 #' @param cohort Vector or list specifying the cohort(s) of interest. Must be
 #'   one of "NSCLC" (Non-Small Cell Lung Cancer), "CRC" (Colorectal Cancer), or
 #'   "BrCa" (Breast Cancer), "PANC" (Pancreatic Cancer), "Prostate" (Prostate Cancer),
-#'   and "BLADDER" (Bladder Cancer).
+#'   and "BLADDER" (Bladder Cancer). This is not case sensitive.
 #' @param version Vector specifying the version of the cohort. Must match one of the
 #'   release versions available for the specified `cohort` (see `synapse_version()` for available cohort versions).
 #'   When entering multiple cohorts, it is inferred that the order of the version
@@ -107,7 +107,21 @@ pull_data_synapse <- function(cohort = NULL, version = NULL,
   token <- .get_synapse_token(username = username, password = password)
 
   # get `cohort` ---
-  select_cohort <- rlang::arg_match(cohort, c("NSCLC", "CRC", "BrCa", "BLADDER", "PANC", "Prostate"),
+
+  # make cohort term not be case sensitive - will require update as new disease areas are added
+  cohort_case <- dplyr::case_when(
+    stringr::str_to_upper(cohort)=="NSCLC" |
+      stringr::str_to_upper(cohort)=="NON-SMALL CELL LUNG CANCER" |
+      stringr::str_to_upper(cohort)=="NON SMALL CELL LUNG CANCER" |
+      stringr::str_to_upper(cohort)=="NONSMALL CELL LUNG CANCER"~ "NSCLC",
+    stringr::str_to_upper(cohort)=="CRC" | stringr::str_to_upper(cohort)=="COLORECTAL CANCER" ~ "CRC",
+    stringr::str_to_upper(cohort)=="BRCA" | stringr::str_to_upper(cohort)=="BREAST CANCER"~ "BrCa",
+    stringr::str_to_upper(cohort)=="BLADDER" ~ "BLADDER",
+    stringr::str_to_upper(cohort)=="PANC" | stringr::str_to_upper(cohort)=="PANCREAS" ~ "PANC",
+    stringr::str_to_upper(cohort)=="PROSTATE" ~ "Prostate"
+  )
+
+  select_cohort <- rlang::arg_match(cohort_case, c("NSCLC", "CRC", "BrCa", "BLADDER", "PANC", "Prostate"),
     multiple = TRUE
   )
 

--- a/R/synapse_version.R
+++ b/R/synapse_version.R
@@ -35,7 +35,21 @@ synapse_version <- function(cohort = NULL, most_recent = FALSE) {
   if (is.null(cohort)){
     select_cohort <- c("NSCLC", "CRC", "BrCa", "BLADDER", "PANC", "Prostate")
   } else {
-    select_cohort <- rlang::arg_match(cohort, c("NSCLC", "CRC", "BrCa", "BLADDER", "PANC", "Prostate"),
+    cohort_case <- dplyr::case_when(
+      stringr::str_to_upper(cohort) == "NSCLC" |
+        stringr::str_to_upper(cohort) == "NON-SMALL CELL LUNG CANCER" |
+        stringr::str_to_upper(cohort) == "NON SMALL CELL LUNG CANCER" |
+        stringr::str_to_upper(cohort) == "NONSMALL CELL LUNG CANCER" ~ "NSCLC",
+      stringr::str_to_upper(cohort) == "CRC" |
+        stringr::str_to_upper(cohort) == "COLORECTAL CANCER" ~ "CRC",
+      stringr::str_to_upper(cohort) == "BRCA" |
+        stringr::str_to_upper(cohort) == "BREAST CANCER" ~ "BrCa",
+      stringr::str_to_upper(cohort) == "BLADDER" ~ "BLADDER",
+      stringr::str_to_upper(cohort) == "PANC" |
+        stringr::str_to_upper(cohort) == "PANCREAS" ~ "PANC",
+      stringr::str_to_upper(cohort) == "PROSTATE" ~ "Prostate"
+    )
+    select_cohort <- rlang::arg_match(cohort_case, c("NSCLC", "CRC", "BrCa", "BLADDER", "PANC", "Prostate"),
                                     multiple = TRUE)
   }
 
@@ -61,7 +75,9 @@ synapse_version <- function(cohort = NULL, most_recent = FALSE) {
   } else {
     synapse_tables_dts %>%
       filter(.data$cohort %in% c(select_cohort)) %>%
-      group_by(.data$cohort, .data$pubcon) %>%
+      group_by(.data$cohort
+               #, .data$pubcon
+               ) %>%
       slice(which.max(.data$numeric_release_date)) %>%
       ungroup() %>%
       arrange(.data$cohort, .data$numeric_release_date) %>%

--- a/man/pull_data_synapse.Rd
+++ b/man/pull_data_synapse.Rd
@@ -16,7 +16,7 @@ pull_data_synapse(
 \item{cohort}{Vector or list specifying the cohort(s) of interest. Must be
 one of "NSCLC" (Non-Small Cell Lung Cancer), "CRC" (Colorectal Cancer), or
 "BrCa" (Breast Cancer), "PANC" (Pancreatic Cancer), "Prostate" (Prostate Cancer),
-and "BLADDER" (Bladder Cancer).}
+and "BLADDER" (Bladder Cancer). This is not case sensitive.}
 
 \item{version}{Vector specifying the version of the cohort. Must match one of the
 release versions available for the specified `cohort` (see `synapse_version()` for available cohort versions).

--- a/tests/testthat/test-pull_data_synapse.R
+++ b/tests/testthat/test-pull_data_synapse.R
@@ -58,11 +58,68 @@ test_that("Test class and length of list for public data", {
 })
 
 test_that("test `cohort` argument specification", {
-  # try to misspecify cohort (lower cases instead of capital)
-  expect_error(pull_data_synapse(
+  skip_if_not(.is_connected_to_genie())
+
+  # expect lower case cohort to work
+  expect_equal(pull_data_synapse(
+    cohort = "NSCLC",
+    version = "v2.2-consortium"
+  ),
+  pull_data_synapse(
     cohort = "nsclc",
     version = "v2.2-consortium"
-  ), "*")
+  ))
+
+  expect_equal(pull_data_synapse(
+    cohort = "CRC",
+    version = "v2.0-public"
+  ),
+  pull_data_synapse(
+    cohort = "crc",
+    version = "v2.0-public"
+  ))
+
+  expect_equal(pull_data_synapse(
+    cohort = "BrCa",
+    version = "v1.2-consortium"
+  ),
+  pull_data_synapse(
+    cohort = "brca",
+    version = "v1.2-consortium"
+  ))
+
+  expect_equal(pull_data_synapse(
+    cohort = "PANC",
+    version = "v1.2-consortium"
+  ),
+  pull_data_synapse(
+    cohort = "pancreas",
+    version = "v1.2-consortium"
+  ))
+
+  expect_equal(pull_data_synapse(
+    cohort = "Prostate",
+    version = "v1.2-consortium"
+  ),
+  pull_data_synapse(
+    cohort = "PrOsTaTe",
+    version = "v1.2-consortium"
+  ))
+
+  expect_equal(pull_data_synapse(
+    cohort = "BLADDER",
+    version = "v1.2-consortium"
+  ),
+  pull_data_synapse(
+    cohort = "bladdER",
+    version = "v1.2-consortium"
+  ))
+
+  # try to misspecify cohort
+  expect_error(pull_data_synapse(
+    cohort = "nsclc3",
+    version = "v2.2-consortium"
+  ), "`cohort` must be one of*")
 })
 
 test_that("test `version` argument specification", {

--- a/tests/testthat/test-synapse_version.R
+++ b/tests/testthat/test-synapse_version.R
@@ -49,3 +49,27 @@ test_that("Test cohort argument", {
            filter(cohort %in% c("NSCLC", "CRC")))
   )
 })
+
+test_that("Test `cohort` argument specification casing", {
+  # expect lower case cohort to work
+  expect_equal(synapse_version(cohort = "NSCLC"),
+               synapse_version(cohort = "nsclc"))
+
+  expect_equal(synapse_version(cohort = "CRC"),
+               synapse_version(cohort = "crC"))
+
+  expect_equal(synapse_version(cohort = "BrCa"),
+               synapse_version(cohort = "BRCA"))
+
+  expect_equal(synapse_version(cohort = "PANC"),
+               synapse_version(cohort = "Pancreas"))
+
+  expect_equal(synapse_version(cohort = "PANC"),
+               synapse_version(cohort = "Panc"))
+
+  expect_equal(synapse_version(cohort = "Prostate"),
+               synapse_version(cohort = "PROState"))
+
+  expect_equal(synapse_version(cohort = "BLADDER"),
+               synapse_version(cohort = "Bladder"))
+})

--- a/tests/testthat/test-synapse_version.R
+++ b/tests/testthat/test-synapse_version.R
@@ -73,3 +73,12 @@ test_that("Test `cohort` argument specification casing", {
   expect_equal(synapse_version(cohort = "BLADDER"),
                synapse_version(cohort = "Bladder"))
 })
+
+test_that("Test most_recent = TRUE", {
+  # expect 1 row per cohort
+  expect_equal(synapse_version(most_recent = TRUE) %>%
+                 nrow(),
+               synapse_version(most_recent = TRUE) %>%
+                 dplyr::distinct(cohort) %>%
+                 nrow())
+})


### PR DESCRIPTION
Update code so that cohort parameter is no longer case sensitive and synapse_version returns most recent version for data (not specific to whether it is public)

For PR submission:
What changes are involved in this pull request? #120 & #128

Is there a GitHub issue corresponding to this pull request? If so, please provide link.

Checklist for PR Reviewer
- [x] Make sure all updates from master branch are pulled to branch issuing pull request
- [x] Confirm package dependencies are installed by running `renv::install()`
- [x] For bug corrections, check that unit test was added
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [x] R CMD Check runs without errors, warnings, and notes
- [x] Document changes from this pull request in `NEWS.md` file
- [x] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website. If there are errors returned, try running `pkgdown::build_site(new_process = FALSE)` for better error messaging.
- [ ] Code coverage is suitable for any new functions/features. Review coverage with `covr::report()`. Before you run, begin in a fresh R session without any packages loaded and set `Sys.setenv(NOT_CRAN="true")`.
- [x] Increment the version number using `usethis::use_version(which = "dev")`
- [ ] Approve and merge pull request
