### PR TITLE
Create analytic cohort: Update to accept multiple cohorts and stack resulting data together

### DIFF
--- a/R/create_analytic_cohort.R
+++ b/R/create_analytic_cohort.R
@@ -18,7 +18,6 @@
 #'   create_analytic_cohort() for multiple cancer cohorts/data releases, supply
 #'   the list returned from the `pull_data_synapse()` function after pulling
 #'   multiple data releases.
-#' `pull_data_synapse()` function.
 #' @param index_ca_seq Index cancer sequence. Default is 1, indicating the
 #' patient's first index cancer. The index cancer is also referred to as the
 #' BPC Project cancer in the GENIE BPC Analytic Data Guide; this is the
@@ -1038,16 +1037,16 @@ create_analytic_cohort <- function(data_synapse,
   names(data_return) <- stringr::str_replace(
     pattern = "cpt",
     replacement = "ngs",
-    string = paste0("cohort_", str_remove(pattern = "cohort_",
+    string = paste0("cohort_", stringr::str_remove(pattern = "cohort_",
                                                      string = df_list_pan_can)))
 
   # warn if >1 data release per cohort
   chk_n_release_coh <- data_return %>%
     purrr::pluck("cohort_pt_char") %>%
-    dplyr::count(.data$cohort, .data$release_version) %>%
+    dplyr::count(.data$cohort, .data$version) %>%
     dplyr::count(.data$cohort) %>%
     dplyr::filter(n > 1) %>%
-    pull(.data$cohort)
+    dplyr::pull(.data$cohort)
 
   if (length(chk_n_release_coh) > 1){
     cli::cli_warn("When creating an analytic cohort, it is recommended to use the most recent data release(s). It is not advisable to base an analytic cohort on multiple data releases of the same cancer cohort ({.val {paste0(chk_n_release_coh, collapse = ', ')}}).")

--- a/R/create_analytic_cohort.R
+++ b/R/create_analytic_cohort.R
@@ -12,8 +12,13 @@
 #'
 #' See the \href{https://genie-bpc.github.io/genieBPC/articles/create_analytic_cohort_vignette.html}{create_analytic_cohort vignette} for further documentation and examples.
 #'
-#' @param data_synapse The item from the nested list returned from
-#' pull_data_synapse() that corresponds to the cancer cohort of interest.
+#' @param data_synapse To run create_analytic_cohort() for a single data
+#'   release, the item from the nested list returned from `pull_data_synapse()`
+#'   that corresponds to the cancer cohort of interest. To run
+#'   create_analytic_cohort() for multiple cancer cohorts/data releases, supply
+#'   the list returned from the `pull_data_synapse()` function after pulling
+#'   multiple data releases.
+#' `pull_data_synapse()` function.
 #' @param index_ca_seq Index cancer sequence. Default is 1, indicating the
 #' patient's first index cancer. The index cancer is also referred to as the
 #' BPC Project cancer in the GENIE BPC Analytic Data Guide; this is the
@@ -80,7 +85,7 @@
 #' cancer-directed regimen (`tbl_drugs`) and next generation sequencing
 #' (`tbl_ngs`) variables.
 #'
-#' @author Jessica Lavery
+#' @author Jessica Lavery, Hannah Fuchs
 #' @export
 #'
 #' @examples
@@ -146,32 +151,104 @@
 #' stringr
 create_analytic_cohort <- function(data_synapse,
                                    index_ca_seq = 1,
-                                   institution,
-                                   stage_dx,
-                                   histology,
-                                   regimen_drugs,
+                                   institution = NULL,
+                                   stage_dx = NULL,
+                                   histology = NULL,
+                                   regimen_drugs = NULL,
                                    regimen_type = "Exact",
-                                   regimen_order,
-                                   regimen_order_type,
+                                   regimen_order = NULL,
+                                   regimen_order_type = NULL,
                                    return_summary = FALSE) {
 
   # check parameters
   # cohort object
   if (missing(data_synapse)) {
-    stop("Specify the cohort object from the nested list returned by the
-         pull_data_synapse() function.")
-  } else if (is.null(data_synapse)) {
-    stop("The object specified for data_synapse does not exist.")
+    stop("Specify the object returned from the call to the pull_data_synapse() function.")
   }
 
-  # check input parameter
-  # trying to check that the pull_data_synapse object returned is
-  # specific to the cohort
-  if (!("pt_char" %in% names(data_synapse))) {
-    stop("The data_synapse parameter is expecting a single cohort, e.g., data_synapse_obj$NSCLC_v2.0.
-         Be sure to specify only one cohort at a time, even if there are multiple cohorts
-         in the data_synapse object.")
+  # determine if the user passed a single cancer cohort object
+  # or an object with multiple cohorts pulled
+  # if data_synapse_depth = 4, they supplied the pull_data_synapse() object
+  # if data_synapse_depth = 3, they supplied the data for a single cohort
+  # release, nested within the pull_data_synapse() object
+  # e.g., pull_data_syn_obj$NSCLC_v2.0 (depth 3) vs pull_data_syn_obj (depth 4)
+  data_synapse_depth <- purrr::pluck_depth(data_synapse)
+
+  # if the data_synapse list specified is of depth 3 (i.e., user specified
+  # pull_data_syn_obj$data_release), then make into higher level list to use
+  # purrr mapping below
+
+  # browser()
+
+  # the purpose of this is to maintain backwards compatibility with the user
+  # specifying the data release object from pull_data_synapse, as in the
+  # original release of this package, while utilizing the updated code in
+  # create_analytic_cohort() that now processes multiple cohorts at a time
+  if (data_synapse_depth == 3){
+    # name of data_synapse input object
+    data_synapse_character <- deparse(substitute(data_synapse))
+
+    # if data_synapse$data_release_vX.X is supplied (i.e., not mapping over
+    # create_analytic_cohort)
+    if (grepl("\\$", data_synapse_character)){
+      # save original data_synapse object
+      data_synapse_original <- data_synapse
+
+      # update data_synapse object to be a nested list
+      assign("data_synapse", list(data_synapse_original))
+
+      names(data_synapse) <- word(data_synapse_character, 2, sep = "\\$")
+      # else conditions refer to when create_analytic_cohort is used in a map
+      # if release version is present (i.e., not NSCLC v1.1-consortium release)
+    } else if (dplyr::select(purrr::pluck(data_synapse, "pt_char"),
+                      any_of("release_version")) %>% ncol() == 1) {
+      # NSCLC v1.1-consortium doesn't have a release variable
+      coh <- purrr::pluck(data_synapse, "pt_char") %>%
+        dplyr::mutate(coh_temp = str_remove_all(pattern = "[:digit:]",
+                                     string = .data$cohort)) %>%
+        dplyr::pull(.data$coh_temp) %>%
+        unique()
+
+      rel <- purrr::pluck(data_synapse, "pt_char") %>%
+        dplyr::select(release_version) %>%
+        tidyr::separate(release_version, into = c("v", "release"), sep = "-",
+                        extra = "drop") %>%
+        unique() %>%
+        dplyr::pull(v)
+
+      data_synapse_original <- data_synapse
+
+      data_synapse <- list(data_synapse_original)
+
+      names(data_synapse) <- paste0(coh, "_v", rel)
+
+    } else if (dplyr::select(pluck(data_synapse, "pt_char"),
+                      any_of("release_version")) %>% ncol() == 0) {
+    #   # NSCLC v1.1-consortium is the only data release doesn't have a
+    #   # release variable
+      data_synapse_original <- data_synapse
+
+      data_synapse <- list(data_synapse_original)
+
+      names(data_synapse) <- "NSCLC_v1.1"
+    }
   }
+
+  # browser()
+
+  # check input parameter
+  # check that the pull_data_synapse object returned is specific to the cohort
+  purrr::map(data_synapse, function(x) {
+    names <- names(x)
+
+    if (!("pt_char" %in% names)) {
+      stop(c(
+        "The data_synapse parameter is expecting a nested list of ",
+        "GENIE BPC datasets as returned from `pull_data_synapse()`."
+      ))
+    }
+  })
+
 
   # if (!(stringr::str_to_upper(cohort) %in% c("NSCLC", "CRC", "BRCA"))) {
   #   stop("Select from available cancer cohorts:
@@ -181,21 +258,21 @@ create_analytic_cohort <- function(data_synapse,
   #  if ( sum(!grepl("^NSCLC$", cohort)>0 , !missing(institution_temp) ,
   # !grepl(c("^DFCI$|^MSK$|^VICC$|^UHN$"), institution_temp)>0 ) >0  ){
 
-  # get cohort name and how it is capitalized in the data_synapse object
-  cohort_temp <- pull(
-    pluck(data_synapse, "pt_char") %>%
-      # remove digits to account for Phase 2 Cohorts
-      mutate(cohort_no_digits = stringr::str_remove_all(pattern = "[:digit:]",
-                              string = .data$cohort)) %>%
-      distinct(.data$cohort_no_digits),
-    "cohort_no_digits"
-  )
+  # get cohort name
+  cohort_temp <- purrr::map(data_synapse, ~pluck(.x, "pt_char") %>%
+                              # remove digits to account for Phase 2 Cohorts
+                              mutate(cohort_no_digits = stringr::str_remove_all(
+                                pattern = "[:digit:]",
+                                string = .data$cohort)) %>%
+                              distinct(.data$cohort_no_digits) %>%
+                              pull("cohort_no_digits") %>%
+                              unique())
 
   # alphabetize drugs in regimen to match
   # how they are stored in variable
   # regimen_drugs
   if (!missing(regimen_drugs)) {
-    regimen_drugs_sorted <- map_chr(
+    regimen_drugs_sorted <- purrr::map_chr(
       strsplit(regimen_drugs, ","), ~
         toString(str_to_lower(str_sort(
           (str_trim(.x))
@@ -205,127 +282,155 @@ create_analytic_cohort <- function(data_synapse,
 
   # index cancer sequence
   # get max # index cancers/pt
-  max_index_ca <- pluck(data_synapse, "ca_dx_index") %>%
-    group_by(.data$cohort, .data$record_id) %>%
-    summarize(n_index = n(), .groups = "drop") %>%
-    summarize(max_n_index = max(.data$n_index))
+  max_index_ca <- purrr::map(data_synapse, ~ .x %>%
+      pluck("ca_dx_index") %>%
+      group_by(.data$cohort, .data$record_id) %>%
+      summarize(n_index = n(), .groups = "drop") %>%
+      summarize(max_n_index = max(.data$n_index)))
 
-  if (max(index_ca_seq) > max_index_ca) {
-    stop(paste0(
-      "There are no patients in the cohort with ", max_index_ca,
-      " index cancer diagnoses. The maximum number of index cancers to
-         one patient is ", max_index_ca, "."
-    ))
-  }
-
-  # participating institutions by cohort
-  if (sum(
-    !missing(institution),
-    grepl("^NSCLC$|^PANC$|^BLADDER$|^PROSTATE$", stringr::str_to_upper(cohort_temp)) > 0
-  ) > 1) {
-    if (sum(!grepl(
-      c("^DFCI$|^MSK$|^VICC$|^UHN$"),
-      stringr::str_to_upper(institution)
-    ) > 0) > 0) {
-      stop("Select from available participating institutions. For NSCLC/PANC/BLADDER/Prostate, the
-           participating institutions were DFCI, MSK, UHN and VICC.")
+  purrr::map(max_index_ca, function(x) {
+    if (max(index_ca_seq) > x$max_n_index) {
+      stop(paste0(
+        "There are no patients in the cohort with ", x$max_n_index,
+        " index cancer diagnoses. The maximum number of index cancers for
+         one patient is ", x$max_n_index, "."
+      ))
     }
-  } else if (sum(!missing(institution), grepl(
-    "^CRC$|^BRCA$",
-    stringr::str_to_upper(cohort_temp)
-  ) > 0) > 1) {
-    if (sum(!grepl(c("^DFCI$|^MSK$|^VICC$"), stringr::str_to_upper(institution))
-    > 0) > 0) {
-      stop("Select from available participating institutions. For CRC/BrCa, the
-           participating institutions were DFCI, MSK and VICC.")
-    }
-  }
+  })
 
-  if (missing(institution) & stringr::str_to_upper(cohort_temp) %in%
-      stringr::str_to_upper(c("NSCLC", "PANC", "BLADDER", "PROSTATE"))) {
-    institution_temp <- c("DFCI", "MSK", "UHN", "VICC")
-  } else if (missing(institution) &
-    stringr::str_to_upper(cohort_temp) %in% c("CRC", "BRCA")) {
-    institution_temp <- c("DFCI", "MSK", "VICC")
+  # institutions
+  # first check all provided are included for that cohort
+  # then assign if not missing
+  # if missing, assign all for a given cohort
+  institution_temp <- if (!is.null(institution)) {
+    purrr::map(1:length(data_synapse), function(x) {
+      if (startsWith(stringr::str_to_upper(cohort_temp[[x]]), "NSCLC")) {
+        if (!all(grepl(c("^DFCI$|^MSK$|^VICC$|^UHN$"),
+                       stringr::str_to_upper(institution)))) {
+          stop(
+            "Select from available participating institutions. For NSCLC, the
+           participating institutions were DFCI, MSK, UHN and VICC."
+          )
+        } else {
+          stringr::str_to_upper({{ institution }})
+        }
+      } else if (stringr::str_to_upper(cohort_temp[[x]]) %in% c("CRC", "BRCA")) {
+        if (length(cohort_temp) == 1 & !all(grepl(
+          c("^DFCI$|^MSK$|^VICC$"),
+          stringr::str_to_upper(institution)
+        ))) {
+          stop(
+            "Select from available participating institutions. For CRC and BrCa,
+            the participating institutions were DFCI, MSK and VICC."
+          )
+        } else {
+          institution[grepl(c("^DFCI$|^MSK$|^VICC$"), str_to_upper(institution))]
+        }
+
+        # if passes through errors, will do the following
+      }
+    })
   } else {
-    institution_temp <- stringr::str_to_upper({{ institution }})
+    purrr::map(1:length(data_synapse), function(x) {
+      if (stringr::str_to_upper(cohort_temp[[x]]) %in% stringr::str_to_upper(c("NSCLC", "PANC", "BLADDER", "PROSTATE"))) {
+        c("DFCI", "MSK", "UHN", "VICC")
+      } else if (stringr::str_to_upper(cohort_temp[[x]]) %in% c("CRC", "BRCA")) {
+        c("DFCI", "MSK", "VICC")
+      }
+    })
   }
 
   # to account for unspecified stage
-  if (missing(stage_dx)) {
-    stage_dx_temp <- pull(pluck(data_synapse, "ca_dx_index") %>%
-      dplyr::distinct(stage_dx), stage_dx)
+
+  if (is.null(stage_dx)) {
+    stage_dx_temp <- purrr::map(data_synapse, function(x) {
+      pull(pluck(x, "ca_dx_index") %>%
+        dplyr::distinct(stage_dx), stage_dx)
+    })
   } else {
-    stage_dx_temp <- {{ stage_dx }}
+    stage_dx_temp <- purrr::map(data_synapse, ~ stage_dx)
   }
 
   # stage mis-specified
-  if (!missing(stage_dx) &&
-    sum(!grepl(
+  if (class(stage_dx) == "list"){
+    stop("`stage_dx` must be a vector, not a list. Note that stage(s)
+        listed apply to all cohorts in the data_synapse object.")
+  } else if (!is.null(stage_dx) &&
+    any(!grepl(
       c("^stage i$|^stage ii$|^stage iii$|
                  ^stage i-iii nos$|^stage iv$"),
-      stringr::str_to_lower(stage_dx)
-    ) > 0) > 0) {
+      stringr::str_to_lower(stage_dx)))) {
     stop("Select from available stages: Stage I, Stage II, Stage III,
          Stage I-III NOS, Stage IV")
   }
 
-  # to account for unspecified histology
-  if (missing(histology)) {
-    if (cohort_temp != "BrCa") {
-      histology_temp <- pull(pluck(data_synapse, "ca_dx_index") %>%
-        distinct(.data$ca_hist_adeno_squamous), .data$ca_hist_adeno_squamous)
-    } else {
-      histology_temp <- pull(
-        pluck(data_synapse, "ca_dx_index") %>%
-          distinct(.data$ca_hist_brca),
-        "ca_hist_brca"
-      )
-    }
-  } else {
-    histology_temp <- {{ histology }}
-  }
-
-
-
-  # histology mis-specified
-  if (!missing(histology) &&
-    cohort_temp != "BrCa" &&
-    sum(!grepl(
-      c("^adenocarcinoma$|^squamous cell$|^sarcoma$|^small cell
-                 carcinoma$|^carcinoma$|^other histologies/mixed tumor$"),
-      stringr::str_to_lower(histology)
-    ) > 0) > 0) {
-    stop("Select from available histology categories: Adenocarcinoma,
+  histology_temp <- if (!is.null(histology)) {
+    # is histology mis-specified?
+    purrr::map(1:length(data_synapse), function(x) {
+      if (class(histology) == "list"){
+        stop("`histology` must be a vector, not a list. Note that histologies
+        listed apply to all cohorts in the data_synapse object.")
+      } else if (cohort_temp[[x]] != "BrCa" &&
+        any(!grepl(
+          c(
+            "^adenocarcinoma$|^squamous cell$|^sarcoma$|^small cell
+                 carcinoma$|^carcinoma$|^other histologies/mixed tumor$"
+          ),
+          stringr::str_to_lower(histology)))) {
+        stop(
+          "Select from available histology categories: Adenocarcinoma,
          Squamous cell, Sarcoma, Small cell carcinoma, Other histologies/mixed
-         tumor")
-  }
-  if (!missing(histology) &&
-    cohort_temp == "BrCa" &&
-    sum(!grepl(
-      c("^invasive lobular carcinoma$|^invasive ductal carcinoma$|
-                 ^Other histology$"),
-      stringr::str_to_lower(histology)
-    ) > 0) > 0) {
-    stop("Select from available histology categories: Invasive lobular
-         carcinoma, Invasive ductal carcinoma, Other histology")
+         tumor"
+        )
+      } else if (cohort_temp[[x]] == "BrCa" &&
+        any(!grepl(
+          c(
+            "^invasive lobular carcinoma$|^invasive ductal carcinoma$|
+                 ^Other histology$"
+          ),
+          histology
+        ))) {
+        stop(
+          "Select from available histology categories: Invasive lobular
+         carcinoma, Invasive ductal carcinoma, Other histology"
+        )
+      } else {
+        histology
+      }
+    })
+  } else {
+    purrr::map(1:length(data_synapse), function(x) {
+      if (cohort_temp[[x]] != "BrCa") {
+        pull(
+          pluck(data_synapse[[x]], "ca_dx_index") %>%
+            distinct(.data$ca_hist_adeno_squamous),
+          .data$ca_hist_adeno_squamous
+        )
+      } else {
+        pull(
+          pluck(data_synapse[[x]], "ca_dx_index") %>%
+            distinct(.data$ca_hist_brca),
+          "ca_hist_brca"
+        )
+      }
+    })
   }
 
   ### drug regimen parameter checks
   # if regimen type is mis-specified
-  if (!missing(regimen_type) | is.numeric(regimen_type)) {
+  if (!is.null(regimen_type) | is.numeric(regimen_type)) {
     if (!(stringr::str_to_lower(regimen_type) %in% c("exact", "containing"))) {
       stop("For regimen_type select from 'exact' or 'containing'")
     }
   }
 
   # if regimen_order is not numeric
-  if (!missing(regimen_order) && !is.numeric(regimen_order)) {
+  if (!is.null(regimen_order) && !is.numeric(regimen_order)) {
     stop("The regimen_order parameter must be a numeric value >=1.")
   }
 
   # if regimen_order_type is mis-specified
-  if (!missing(regimen_order_type) &&
+  if (!is.null(regimen_order_type) &&
     (is.numeric(regimen_order_type) ||
       !(stringr::str_to_lower(regimen_order_type) %in% c(
         "within cancer",
@@ -336,503 +441,624 @@ create_analytic_cohort <- function(data_synapse,
   }
 
   # regimen_order_type needs to be specified if regimen_order is specified
-  if (missing(regimen_order_type) && !missing(regimen_order)) {
+  if (is.null(regimen_order_type) && !is.null(regimen_order)) {
     stop("Regimen order type must also be specified. Choose from
          'within cancer' or 'within regimen'")
   }
 
   # can't only specify regimen_order_type
-  if (!missing(regimen_order_type) && missing(regimen_order)) {
+  if (!is.null(regimen_order_type) && is.null(regimen_order)) {
     stop("Numeric order must also be specified in 'regimen_order' argument.")
   }
 
   # if regimen_type is specified, regimen_drugs must also be specified
-  if (!missing(regimen_type) && missing(regimen_drugs)) {
+  if (regimen_type != "Exact" && is.null(regimen_drugs)) {
     stop("If regimen_type is specified, regimen_drugs must also be specified.")
   }
 
-  if (missing(regimen_order_type)) {
+  if (is.null(regimen_order_type)) {
     regimen_order_type <- NULL
   }
 
   ##############################################################################
   #                             pull cancer cohort                             #
   ##############################################################################
+
   # select patients based on cohort, institution, stage at diagnosis,
   # histology and cancer number
-  if (cohort_temp != "BrCa") {
-    cohort_ca_dx <- pluck(data_synapse, "ca_dx_index") %>%
-      # re-number index cancer diagnoses
-      dplyr::group_by(.data$cohort, .data$record_id) %>%
-      dplyr::mutate(index_ca_seq = 1:n()) %>%
-      dplyr::ungroup() %>%
-      # apply filter(s)
-      dplyr::filter(
-        stringr::str_to_lower(.data$institution) %in%
-          stringr::str_to_lower(c(institution_temp)),
-        stringr::str_to_lower(.data$stage_dx) %in%
-          stringr::str_to_lower(c(stage_dx_temp)),
-        stringr::str_to_lower(.data$ca_hist_adeno_squamous) %in%
-          stringr::str_to_lower(c(histology_temp)),
-        .data$index_ca_seq %in% c({{ index_ca_seq }})
-      )
-  } else {
-    cohort_ca_dx <- pluck(data_synapse, "ca_dx_index") %>%
-      # re-number index cancer diagnoses
-      dplyr::group_by(.data$cohort, .data$record_id) %>%
-      dplyr::mutate(index_ca_seq = 1:n()) %>%
-      dplyr::ungroup() %>%
-      # # apply filter(s)
-      dplyr::filter(
-        stringr::str_to_lower(.data$institution) %in%
-          stringr::str_to_lower(c(institution_temp)),
-        stringr::str_to_lower(.data$stage_dx) %in%
-          stringr::str_to_lower(c(stage_dx_temp)),
-        stringr::str_to_lower(.data$ca_hist_brca) %in%
-          stringr::str_to_lower(c(histology_temp)),
-        .data$index_ca_seq %in% c({{ index_ca_seq }})
-      )
-  }
+  cohort_ca_dx <- purrr::map(1:length(data_synapse), function(x) {
+    if (cohort_temp[[x]] != "BrCa") {
+      pluck(data_synapse[[x]], "ca_dx_index") %>%
+        # re-number index cancer diagnoses
+        dplyr::group_by(.data$cohort, .data$record_id) %>%
+        dplyr::mutate(index_ca_seq = 1:n()) %>%
+        dplyr::ungroup() %>%
+        # apply filter(s)
+        dplyr::filter(
+          stringr::str_to_lower(.data$institution) %in%
+            stringr::str_to_lower(unlist(institution_temp[[x]])),
+          stringr::str_to_lower(.data$stage_dx) %in%
+            stringr::str_to_lower(unlist(stage_dx_temp[[x]])),
+          stringr::str_to_lower(.data$ca_hist_adeno_squamous) %in%
+            stringr::str_to_lower(unlist(histology_temp[[x]])),
+          .data$index_ca_seq %in% c({{ index_ca_seq }})
+        )
+    } else {
+      pluck(data_synapse[[x]], "ca_dx_index") %>%
+        # re-number index cancer diagnoses
+        dplyr::group_by(.data$cohort, .data$record_id) %>%
+        dplyr::mutate(index_ca_seq = 1:n()) %>%
+        dplyr::ungroup() %>%
+        # # apply filter(s)
+        dplyr::filter(
+          stringr::str_to_lower(.data$institution) %in%
+            stringr::str_to_lower(c(institution_temp[[x]])),
+          stringr::str_to_lower(.data$stage_dx) %in%
+            stringr::str_to_lower(c(stage_dx_temp[[x]])),
+          stringr::str_to_lower(.data$ca_hist_brca) %in%
+            stringr::str_to_lower(c(histology_temp[[x]])),
+          .data$index_ca_seq %in% c({{ index_ca_seq }})
+        )
+    }
+  })
 
-
+  # only continue if patients met the inclusion criteria
+  if (any(map(cohort_ca_dx, nrow) > 0)){
 
   # pull drug regimens to those patients
   # option 1: all drug regimens to all patients in cohort
   # regimen_drugs is not specified, regimen_order is not specified
-  cohort_ca_drugs <- dplyr::inner_join(cohort_ca_dx %>%
-   dplyr::select("cohort", "record_id", "ca_seq"),
-  pluck(data_synapse, "ca_drugs"),
-  by = c("cohort", "record_id", "ca_seq")
-  ) %>%
-    # create order for drug regimen within cancer and within times the
-    # drug was received
-    dplyr::group_by(.data$cohort, .data$record_id, .data$ca_seq) %>%
-    dplyr::arrange(
-      .data$cohort, .data$record_id,
-      .data$ca_seq, .data$regimen_number
-    ) %>%
-    dplyr::mutate(order_within_cancer = 1:n()) %>%
-    dplyr::ungroup() %>%
-    # order drugs w/in regimen, have to account for structure of data which is
-    # 1 reg:assoc ca dx
-    # (may have more than one row for a drug regimen even if it's the first time
-    # that drug regimen was received)
-    dplyr::left_join(.,
-      pluck(data_synapse, "ca_drugs") %>%
-        dplyr::distinct(
-          .data$record_id, .data$regimen_number,
-          .data$regimen_drugs
-        ) %>%
-        dplyr::group_by(.data$record_id, .data$regimen_drugs) %>%
-        dplyr::arrange(
-          .data$record_id, .data$regimen_number,
-          .data$regimen_drugs
-        ) %>%
-        dplyr::mutate(order_within_regimen = 1:n()) %>%
-        dplyr::ungroup() %>%
-        dplyr::select(-"regimen_drugs"),
-      by = c("record_id", "regimen_number")
-    ) %>%
-    dplyr::left_join(.,
-      genieBPC::regimen_abbreviations,
-      by = c("regimen_drugs")
-    )
-
-
+  cohort_ca_drugs <- purrr::map2(cohort_ca_dx, data_synapse,
+                                 ~dplyr::inner_join(
+      .x %>%
+        dplyr::select("cohort", "record_id", "ca_seq"),
+      pluck(.y, "ca_drugs"),
+      by = c("cohort", "record_id", "ca_seq")
+      ) %>%
+      # create order for drug regimen within cancer and within times the
+      # drug was received
+      dplyr::group_by(.data$cohort, .data$record_id, .data$ca_seq) %>%
+      dplyr::arrange(
+        .data$cohort, .data$record_id,
+        .data$ca_seq, .data$regimen_number
+      ) %>%
+      dplyr::mutate(order_within_cancer = 1:n()) %>%
+      dplyr::ungroup() %>%
+      # order drugs w/in regimen, have to account for structure of data which is
+      # 1 reg:assoc ca dx
+      # (may have more than one row for a drug regimen even if it's the first time
+      # that drug regimen was received)
+      dplyr::left_join(.,
+        pluck(.y, "ca_drugs") %>%
+          dplyr::distinct(
+            .data$record_id, .data$regimen_number,
+            .data$regimen_drugs
+          ) %>%
+          dplyr::group_by(.data$record_id, .data$regimen_drugs) %>%
+          dplyr::arrange(
+            .data$record_id, .data$regimen_number,
+            .data$regimen_drugs
+          ) %>%
+          dplyr::mutate(order_within_regimen = 1:n()) %>%
+          dplyr::ungroup() %>%
+          dplyr::select(-"regimen_drugs"),
+        by = c("record_id", "regimen_number")
+      ) %>%
+      dplyr::left_join(.,
+        genieBPC::regimen_abbreviations,
+        by = c("regimen_drugs")
+      )
+  )
 
   # option 2: all "first line" drug regimens (regimens of a certain number,
   # within a cancer diagnosis)
   # specific regimen number to all pts in cohort, any regimen name
   # regimen_drugs is not specified, regimen_order is specified and
   # regimen_type = "within cancer"
-  if (missing(regimen_drugs) && !missing(regimen_order) &&
+  if (is.null(regimen_drugs) && !is.null(regimen_order) &&
     stringr::str_to_lower(regimen_order_type) == "within cancer") {
 
-    # cohort_ca_drugs <- dplyr::left_join(cohort_ca_dx,
-    #   pluck(data_synapse, paste0("ca_drugs_", cohort_temp)),
-    #   by = c("cohort", "record_id", "institution", "ca_seq")
-    # ) %>%
-    #   dplyr::filter(.data$order_within_cancer %in% c({{ regimen_order }}))
+      cohort_ca_drugs <- purrr::map(1:length(data_synapse), function(x) {
+        cohort_ca_drugs[[x]] %>%
+        dplyr::filter(.data$order_within_cancer %in% c({{ regimen_order }}))
+      })
 
-    cohort_ca_drugs <- cohort_ca_drugs %>%
-      dplyr::filter(.data$order_within_cancer %in% c({{ regimen_order }}))
-
-    # restrict cancer cohort to all patients who got a drug regimen
-    cohort_ca_dx <- dplyr::inner_join(cohort_ca_dx,
-      cohort_ca_drugs %>%
-        dplyr::filter(.data$order_within_cancer %in% c({{ regimen_order }})) %>%
-        dplyr::select("cohort", "record_id", "institution", "ca_seq"),
-      by = c(
-        "cohort", "record_id", "institution", "ca_seq"
+      # restrict cancer cohort to all patients who got a drug regimen
+      cohort_ca_dx <- purrr::map(1:length(data_synapse), function(x) {
+        dplyr::inner_join(cohort_ca_dx[[x]],
+        cohort_ca_drugs[[x]] %>%
+          dplyr::filter(.data$order_within_cancer %in% c({{ regimen_order }})) %>%
+          dplyr::select("cohort", "record_id", "institution", "ca_seq"),
+        by = c(
+          "cohort", "record_id", "institution", "ca_seq"
+        )
       )
-    )
+    })
   }
-
 
 
   # if specific drug regimen is requested; exact regimen
   # option 3a: all times that exact drug regimen was received
-  if (!missing(regimen_drugs) && missing(regimen_order) &&
+  if (!is.null(regimen_drugs) && is.null(regimen_order) &&
     stringr::str_to_lower(regimen_type) == "exact") {
     # identify instances of that drug regimen
-    cohort_ca_drugs <- cohort_ca_drugs %>%
-      dplyr::filter(
-        str_to_lower(.data$regimen_drugs) %in% c(regimen_drugs_sorted) |
-          str_to_lower(.data$abbreviation) %in% c(regimen_drugs_sorted) #|
-        # drug_class %in% c(regimen_drugs_sorted)
+    cohort_ca_drugs <- purrr::map(1:length(data_synapse), function(x) {
+      cohort_ca_drugs[[x]] %>%
+        dplyr::filter(
+          str_to_lower(.data$regimen_drugs) %in% c(regimen_drugs_sorted) |
+            str_to_lower(.data$abbreviation) %in% c(regimen_drugs_sorted) #|
+          # drug_class %in% c(regimen_drugs_sorted)
+        )})
+
+      # restrict cancer cohort to patients on that drug regimen
+      cohort_ca_dx <- purrr::map(1:length(data_synapse), function(x) {
+        dplyr::inner_join(cohort_ca_dx[[x]],
+        cohort_ca_drugs[[x]] %>%
+          dplyr::distinct(
+            .data$cohort, .data$record_id, .data$institution,
+            .data$ca_seq
+          ),
+        by = c("cohort", "record_id", "institution", "ca_seq")
       )
-
-    # restrict cancer cohort to patients on that drug regimen
-    cohort_ca_dx <- dplyr::inner_join(cohort_ca_dx,
-      cohort_ca_drugs %>%
-        dplyr::distinct(
-          .data$cohort, .data$record_id, .data$institution,
-          .data$ca_seq
-        ),
-      by = c("cohort", "record_id", "institution", "ca_seq")
-    )
+    })
   }
-
 
   # option 3b: all times that regimen containing drugs was received
-  if (!missing(regimen_drugs) && missing(regimen_order) &&
+
+  if (!is.null(regimen_drugs) && is.null(regimen_order) &&
     stringr::str_to_lower(regimen_type) == "containing") {
-    # identify instances of that drug regimen
-    cohort_ca_drugs <- cohort_ca_drugs %>%
-      dplyr::filter(grepl(
-        paste(regimen_drugs_sorted, collapse = "|"),
-        str_to_lower(.data$regimen_drugs)
-      ) |
-        grepl(
+    cohort_ca_drugs <- purrr::map(1:length(data_synapse), function(x) {
+      # identify instances of that drug regimen
+       cohort_ca_drugs[[x]] %>%
+        dplyr::filter(grepl(
           paste(regimen_drugs_sorted, collapse = "|"),
-          str_to_lower(.data$abbreviation)
-        ))
-
-    # restrict cancer cohort to patients on that drug regimen
-    cohort_ca_dx <- dplyr::inner_join(cohort_ca_dx,
-      cohort_ca_drugs %>%
-        dplyr::distinct(
-          .data$cohort, .data$record_id, .data$institution,
-          .data$ca_seq
-        ),
-      by = c("cohort", "record_id", "institution", "ca_seq")
-    )
-  }
-
-  # option 4a: 1st (or other) time that exact regimen was received
-  if (!missing(regimen_drugs) && !missing(regimen_order) &&
-    stringr::str_to_lower(regimen_order_type) == "within regimen" &&
-    stringr::str_to_lower(regimen_type) == "exact") {
-    # identify instances of that drug regimen
-    cohort_ca_drugs <- cohort_ca_drugs %>%
-      dplyr::filter(str_to_lower(.data$regimen_drugs)
-      %in% c(regimen_drugs_sorted) |
-        str_to_lower(.data$abbreviation) %in% c(regimen_drugs_sorted)) %>%
-      # filter on order of interest (e.g. first, all)
-      dplyr::filter(.data$order_within_regimen %in% c({{ regimen_order }}))
-
-    # restrict cancer cohort to patients on that drug regimen
-    cohort_ca_dx <- dplyr::inner_join(cohort_ca_dx,
-      cohort_ca_drugs %>%
-        distinct(
-          .data$cohort, .data$record_id, .data$institution,
-          .data$ca_seq
-        ),
-      by = c("cohort", "record_id", "institution", "ca_seq")
-    )
-  }
-
-  # option 4b: 1st (or other) time that regimen containing was received
-  if (!missing(regimen_drugs) &&
-    !missing(regimen_order) &&
-    stringr::str_to_lower(regimen_order_type) == "within regimen" &&
-    stringr::str_to_lower(regimen_type) == "containing") {
-    # identify instances of that drug regimen
-    # have to start with full drugs dataset for 'within regimen',
-    # otherwise are left with all drug regimens to pts in this cohort
-    cohort_ca_drugs <- pluck(data_synapse, "ca_drugs") %>%
-      # add on abbreviations
-      dplyr::left_join(.,
-        genieBPC::regimen_abbreviations,
-        by = c("regimen_drugs")
-      ) %>%
-      # create new order b/c this is regimen CONTAINING drugs listed
-      # order drugs w/in regimen, have to account for
-      # structure of data which is
-      # 1 reg:assoc ca dx
-      # (may have more than one row for a drug regimen even
-      # if it's the first time
-      # that drug regimen was received)
-      # have to filter on containing regimens first, then re-number
-      dplyr::filter(grepl(
-        paste(regimen_drugs_sorted, collapse = "|"),
-        str_to_lower(.data$regimen_drugs)
-      ) |
-        grepl(
-          paste(regimen_drugs_sorted, collapse = "|"),
-          str_to_lower(.data$abbreviation)
-        )) %>%
-      # now re-number w/in containing regimens
-      dplyr::left_join(.,
-        pluck(data_synapse, "ca_drugs") %>%
-          # add on abbreviations
-          dplyr::left_join(.,
-            genieBPC::regimen_abbreviations,
-            by = c("regimen_drugs")
-          ) %>%
-          # get regimens containing drugs of interest
-          dplyr::filter(grepl(
-            paste(regimen_drugs_sorted, collapse = "|"),
-            str_to_lower(.data$regimen_drugs)
-          ) |
-            grepl(
-              paste(regimen_drugs_sorted, collapse = "|"),
-              str_to_lower(.data$abbreviation)
-            )) %>%
-          # get distinct regimen administrations (since regs
-          # potentially mapped to multiple ca types)
-          dplyr::distinct(
-            .data$record_id, .data$regimen_number,
-            .data$regimen_drugs
-          ) %>%
-          # order regimens
-          dplyr::group_by(.data$record_id) %>%
-          dplyr::arrange(
-            .data$record_id, .data$regimen_number,
-            .data$regimen_drugs
-          ) %>%
-          dplyr::mutate(
-            order_within_containing_regimen = 1:n()
-          ) %>%
-          dplyr::ungroup() %>%
-          dplyr::select(-"regimen_drugs"),
-        by = c("record_id", "regimen_number")
-      ) %>%
-      # filter on order of interest (e.g. first, all)
-      dplyr::filter(.data$order_within_containing_regimen
-        %in% c({{ regimen_order }})) %>%
-      # restrict to patients in the cohort (started with all regimens to all
-      # patients)
-      dplyr::inner_join(.,
-        cohort_ca_dx %>%
-          dplyr::select("cohort", "record_id", "ca_seq"),
-        by = c("cohort", "record_id", "ca_seq")
-      ) %>%
-      # create blank variables (dropped below, not having them is unique to
-      # regimen_order_type = 'containing')
-      mutate(
-        order_within_cancer = as.numeric(NA),
-        order_within_regimen = as.numeric(NA)
-      )
-
-    # restrict cancer cohort to patients on that drug regimen
-    cohort_ca_dx <- inner_join(cohort_ca_dx,
-      cohort_ca_drugs %>%
-        dplyr::distinct(
-          .data$cohort, .data$record_id, .data$institution,
-          .data$ca_seq
-        ),
-      by = c("cohort", "record_id", "institution", "ca_seq")
-    )
-  }
-
-  # option 5a: specific drugs within a cancer diagnosis, exact regimen
-  if (!missing(regimen_drugs) &&
-    !missing(regimen_order) &&
-    stringr::str_to_lower(regimen_type) == "exact" &&
-    stringr::str_to_lower(regimen_order_type) == "within cancer") {
-    # identify instances of that drug regimen
-    cohort_ca_drugs <- cohort_ca_drugs %>%
-      dplyr::filter(
-        str_to_lower(.data$regimen_drugs) %in% c(regimen_drugs_sorted) |
-          str_to_lower(.data$abbreviation) %in% c(regimen_drugs_sorted),
-        .data$order_within_cancer %in% c({{ regimen_order }})
-      )
-
-    # restrict cancer cohort to patients on that drug regimen
-    cohort_ca_dx <- dplyr::inner_join(cohort_ca_dx,
-      cohort_ca_drugs %>%
-        distinct(
-          .data$cohort, .data$record_id, .data$institution,
-          .data$ca_seq
-        ),
-      by = c("cohort", "record_id", "institution", "ca_seq")
-    )
-  }
-
-  # option 5b: specific drugs within a cancer diagnosis, regimen containing
-  if (!missing(regimen_drugs) &&
-    !missing(regimen_order) &&
-    stringr::str_to_lower(regimen_type) == "containing" &&
-    stringr::str_to_lower(regimen_order_type) == "within cancer") {
-    # identify instances of that drug regimen
-    cohort_ca_drugs <- cohort_ca_drugs %>%
-      dplyr::filter(
-        grepl(paste(regimen_drugs_sorted,
-          collapse = "|"
-        ), str_to_lower(.data$regimen_drugs)) |
+          str_to_lower(.data$regimen_drugs)
+        ) |
           grepl(
             paste(regimen_drugs_sorted, collapse = "|"),
             str_to_lower(.data$abbreviation)
-          ),
-        .data$order_within_cancer %in% c({{ regimen_order }})
-      )
+          ))})
 
-    # restrict cancer cohort to patients on that drug regimen
-    cohort_ca_dx <- dplyr::inner_join(cohort_ca_dx,
-      cohort_ca_drugs %>%
-        dplyr::distinct(
-          .data$cohort, .data$record_id, .data$institution,
-          .data$ca_seq
-        ),
-      by = c("cohort", "record_id", "institution", "ca_seq")
-    )
+      # restrict cancer cohort to patients on that drug regimen
+      cohort_ca_dx <- purrr::map(1:length(data_synapse), function(x) {
+        dplyr::inner_join(cohort_ca_dx[[x]],
+        cohort_ca_drugs[[x]] %>%
+          dplyr::distinct(
+            .data$cohort, .data$record_id, .data$institution,
+            .data$ca_seq
+          ),
+        by = c("cohort", "record_id", "institution", "ca_seq")
+      )
+    })
+  }
+
+  # option 4a: 1st (or other) time that exact regimen was received
+  if (!is.null(regimen_drugs) && !is.null(regimen_order) &&
+    stringr::str_to_lower(regimen_order_type) == "within regimen" &&
+    stringr::str_to_lower(regimen_type) == "exact") {
+
+      # identify instances of that drug regimen
+      cohort_ca_drugs <- purrr::map(1:length(data_synapse), function(x) {
+        cohort_ca_drugs[[x]] %>%
+        dplyr::filter(str_to_lower(.data$regimen_drugs)
+        %in% c(regimen_drugs_sorted) |
+          str_to_lower(.data$abbreviation) %in% c(regimen_drugs_sorted)) %>%
+        # filter on order of interest (e.g. first, all)
+        dplyr::filter(.data$order_within_regimen %in% c({{ regimen_order }}))
+      })
+
+      # restrict cancer cohort to patients on that drug regimen
+      cohort_ca_dx <- purrr::map(1:length(data_synapse), function(x) {
+        dplyr::inner_join(cohort_ca_dx[[x]],
+        cohort_ca_drugs[[x]] %>%
+          distinct(
+            .data$cohort, .data$record_id, .data$institution,
+            .data$ca_seq
+          ),
+        by = c("cohort", "record_id", "institution", "ca_seq")
+      )
+    })
+  }
+
+  # option 4b: 1st (or other) time that regimen containing was received
+  if (!is.null(regimen_drugs) &&
+    !is.null(regimen_order) &&
+    stringr::str_to_lower(regimen_order_type) == "within regimen" &&
+    stringr::str_to_lower(regimen_type) == "containing") {
+
+      # identify instances of that drug regimen
+      # have to start with full drugs dataset for 'within regimen',
+      # otherwise are left with all drug regimens to pts in this cohort
+      cohort_ca_drugs <- purrr::map(1:length(data_synapse), function(x) {
+        pluck(data_synapse[[x]], "ca_drugs") %>%
+        # add on abbreviations
+        dplyr::left_join(.,
+          genieBPC::regimen_abbreviations,
+          by = c("regimen_drugs")
+        ) %>%
+        # create new order b/c this is regimen CONTAINING drugs listed
+        # order drugs w/in regimen, have to account for
+        # structure of data which is
+        # 1 reg:assoc ca dx
+        # (may have more than one row for a drug regimen even
+        # if it's the first time
+        # that drug regimen was received)
+        # have to filter on containing regimens first, then re-number
+        dplyr::filter(grepl(
+          paste(regimen_drugs_sorted, collapse = "|"),
+          str_to_lower(.data$regimen_drugs)
+        ) |
+          grepl(
+            paste(regimen_drugs_sorted, collapse = "|"),
+            str_to_lower(.data$abbreviation)
+          )) %>%
+        # now re-number w/in containing regimens
+        dplyr::left_join(.,
+          pluck(data_synapse[[x]], "ca_drugs") %>%
+            # add on abbreviations
+            dplyr::left_join(.,
+              genieBPC::regimen_abbreviations,
+              by = c("regimen_drugs")
+            ) %>%
+            # get regimens containing drugs of interest
+            dplyr::filter(grepl(
+              paste(regimen_drugs_sorted, collapse = "|"),
+              str_to_lower(.data$regimen_drugs)
+            ) |
+              grepl(
+                paste(regimen_drugs_sorted, collapse = "|"),
+                str_to_lower(.data$abbreviation)
+              )) %>%
+            # get distinct regimen administrations (since regs
+            # potentially purrr::mapped to multiple ca types)
+            dplyr::distinct(
+              .data$record_id, .data$regimen_number,
+              .data$regimen_drugs
+            ) %>%
+            # order regimens
+            dplyr::group_by(.data$record_id) %>%
+            dplyr::arrange(
+              .data$record_id, .data$regimen_number,
+              .data$regimen_drugs
+            ) %>%
+            dplyr::mutate(
+              order_within_containing_regimen = 1:n()
+            ) %>%
+            dplyr::ungroup() %>%
+            dplyr::select(-"regimen_drugs"),
+          by = c("record_id", "regimen_number")
+        ) %>%
+        # filter on order of interest (e.g. first, all)
+        dplyr::filter(.data$order_within_containing_regimen
+          %in% c({{ regimen_order }})) %>%
+        # restrict to patients in the cohort (started with all regimens to all
+        # patients)
+        dplyr::inner_join(.,
+          cohort_ca_dx[[x]] %>%
+            dplyr::select("cohort", "record_id", "ca_seq"),
+          by = c("cohort", "record_id", "ca_seq")
+        ) %>%
+        # create blank variables (dropped below, not having them is unique to
+        # regimen_order_type = 'containing')
+        mutate(
+          order_within_cancer = as.numeric(NA),
+          order_within_regimen = as.numeric(NA)
+        )
+      })
+
+      # restrict cancer cohort to patients on that drug regimen
+      cohort_ca_dx <- purrr::map(1:length(data_synapse), function(x) {
+        inner_join(cohort_ca_dx[[x]],
+        cohort_ca_drugs[[x]] %>%
+          dplyr::distinct(
+            .data$cohort, .data$record_id, .data$institution,
+            .data$ca_seq
+          ),
+        by = c("cohort", "record_id", "institution", "ca_seq")
+      )
+    })
+  }
+
+  # option 5a: specific drugs within a cancer diagnosis, exact regimen
+
+  if (!is.null(regimen_drugs) &&
+    !is.null(regimen_order) &&
+    stringr::str_to_lower(regimen_type) == "exact" &&
+    stringr::str_to_lower(regimen_order_type) == "within cancer") {
+
+      # identify instances of that drug regimen
+      cohort_ca_drugs <- purrr::map(1:length(data_synapse), function(x) {
+        cohort_ca_drugs[[x]] %>%
+        dplyr::filter(
+          str_to_lower(.data$regimen_drugs) %in% c(regimen_drugs_sorted) |
+            str_to_lower(.data$abbreviation) %in% c(regimen_drugs_sorted),
+          .data$order_within_cancer %in% c({{ regimen_order }})
+        )
+      })
+
+      # restrict cancer cohort to patients on that drug regimen
+      cohort_ca_dx <- purrr::map(1:length(data_synapse), function(x) {
+        dplyr::inner_join(cohort_ca_dx[[x]],
+        cohort_ca_drugs[[x]] %>%
+          distinct(
+            .data$cohort, .data$record_id, .data$institution,
+            .data$ca_seq
+          ),
+        by = c("cohort", "record_id", "institution", "ca_seq")
+      )
+    })
+  }
+
+
+  # option 5b: specific drugs within a cancer diagnosis, regimen containing
+  if (!is.null(regimen_drugs) &&
+    !is.null(regimen_order) &&
+    stringr::str_to_lower(regimen_type) == "containing" &&
+    stringr::str_to_lower(regimen_order_type) == "within cancer") {
+
+      # identify instances of that drug regimen
+      cohort_ca_drugs <- purrr::map(1:length(data_synapse), function(x) {
+        cohort_ca_drugs[[x]] %>%
+        dplyr::filter(
+          grepl(paste(regimen_drugs_sorted,
+            collapse = "|"
+          ), str_to_lower(.data$regimen_drugs)) |
+            grepl(
+              paste(regimen_drugs_sorted, collapse = "|"),
+              str_to_lower(.data$abbreviation)
+            ),
+          .data$order_within_cancer %in% c({{ regimen_order }})
+        )
+      })
+
+      # restrict cancer cohort to patients on that drug regimen
+      cohort_ca_dx <- purrr::map(1:length(data_synapse), function(x) {
+        dplyr::inner_join(cohort_ca_dx[[x]],
+        cohort_ca_drugs[[x]] %>%
+          dplyr::distinct(
+            .data$cohort, .data$record_id, .data$institution,
+            .data$ca_seq
+          ),
+        by = c("cohort", "record_id", "institution", "ca_seq")
+      )
+    })
   }
 
   # for patients meeting the specified criteria, also pull related datasets
-  # patient characteristics
-  cohort_pt_char <- dplyr::inner_join(cohort_ca_dx %>%
-    dplyr::select("cohort", "record_id"),
-  pluck(data_synapse, "pt_char"),
-  by = c("cohort", "record_id")
+  # for each dataframe returned by pull_data_synapse, return the data
+  # subset to match the specified cohort
+  subset_all_dfs <- purrr::map(1:length(data_synapse), function(x) {
+    # get specific datasets for each cohort/data release in data_synapse
+    genie_dfs <- names(data_synapse[[x]])
+
+    # get cohort and version corresponding to data release to add to all returned datasets
+    # variable release_version is on clinical datasets, but not on genomic data
+    # so when create_analytic_cohort is called for multiple cohorts and the
+    # resulting data is stacked together, need to be able to distinguish btwn
+    # data releases
+    cohort <- word(names(data_synapse[x]), 1, sep = "_")
+    version <- word(names(data_synapse[x]), 2, sep = "_")
+
+    # browser()
+    # then for each of those datasets, subset on the patients of interest
+    purrr::map(genie_dfs, function(df_name) {
+      # datasets that don't require subsetting (cancer dx + ca_drugs) because
+      # they were already processed
+      if (df_name %in% c("ca_dx_index")){
+        cohort_ca_dx[[x]] %>%
+          dplyr::select(-"index_ca_seq") %>%
+          dplyr::mutate(version = version)
+      } else if (df_name %in% c("ca_drugs")) {
+        cohort_ca_drugs[[x]] %>%
+          dplyr::select(-"order_within_cancer",
+                        -"order_within_regimen",
+                        -"abbreviation") %>%
+          dplyr::mutate(version = version)
+
+        # datasets that get can be subset by record_id
+        } else if (df_name %in% c("pt_char", "ca_dx_non_index",
+                         "prissmm_imaging", "prissmm_pathology",
+                         "prissmm_md", "tumor_marker") &
+          !is.null(pluck(data_synapse[[x]], df_name))) {
+        dplyr::inner_join(cohort_ca_dx[[x]] %>%
+                             dplyr::select("cohort", "record_id"),
+                           pluck(data_synapse[[x]], df_name),
+                           by = c("cohort", "record_id")) %>%
+            dplyr::mutate(version = version)
+        # datasets that require merging by cohort, record_id, ca_seq
+      } else if (df_name %in% c("ca_radtx") &
+                 !is.null(pluck(data_synapse[[x]], df_name))) {
+        dplyr::inner_join(cohort_ca_dx[[x]] %>%
+                            dplyr::select("cohort", "record_id", "ca_seq"),
+                          pluck(data_synapse[[x]], df_name),
+                          by = c("cohort", "record_id", "ca_seq")) %>%
+          dplyr::mutate(version = version)
+      } else if (df_name == "cpt") {
+        # cancer panel test information
+        # keep records based on record_id + cancer sequence of interest
+        cpt <- dplyr::inner_join(
+          cohort_ca_dx[[x]] %>%
+            dplyr::select("cohort", "record_id", "ca_seq"),
+          pluck(data_synapse[[x]], df_name),
+          by = c("cohort", "record_id", "ca_seq")
+        ) %>%
+          dplyr::mutate(version = version)
+
+        # if variable sample_type isn't on the NGS dataframe (earlier data
+        # releases), define it here
+        if (any(names(cpt) == "cpt_sample_type") &
+          !any(names(cpt) == "sample_type")) {
+          cpt %>%
+            dplyr::mutate(
+              sample_type = case_when(
+                str_to_lower(.data$cpt_sample_type)
+                %in% c("1", "primary", "primary tumor") ~ "Primary tumor",
+                str_to_lower(.data$cpt_sample_type)
+                %in% c("2", "lymph node metastasis") ~ "Lymph node metastasis",
+                str_to_lower(.data$cpt_sample_type)
+                %in% c("3", "distant organ metastasis") ~ "Distant organ metastasis",
+                str_to_lower(.data$cpt_sample_type)
+                %in% c("4", "metastasis site unspecified", "metastatic recurrence") ~
+                  "Metastasis site unspecified",
+                str_to_lower(.data$cpt_sample_type)
+                %in% c("5", "local recurrence") ~ "Local recurrence",
+                str_to_lower(.data$cpt_sample_type)
+                %in% c("6", "unspecified") ~ as.character(NA),
+                str_to_lower(.data$cpt_sample_type)
+                %in% c("7", "not applicable or hematologic malignancy") ~
+                  "Not applicable or hematologic malignancy"
+              )
+            )
+        } else {
+          cpt
+        }
+        } else if (df_name %in% c("cna")) {
+        # cna file is 1 col / tumor sample barcode
+        # all genes are first column and every name is a column title.
+        if (!is.null(pluck(data_synapse[[x]], df_name))) {
+          # get list of IDs to keep
+          cpt_barcode_keep <- pluck(data_synapse[[x]], "cpt") %>%
+            mutate(
+              Tumor_Sample_Barcode =
+                stringr::str_replace_all(.data$cpt_genie_sample_id,
+                  pattern = "-",
+                  replacement = "\\."
+                )
+            ) %>%
+            pull("Tumor_Sample_Barcode")
+
+          pluck(data_synapse[[x]], df_name) %>%
+            select("Hugo_Symbol", any_of(cpt_barcode_keep)) %>%
+            dplyr::mutate(cohort = cohort,
+                          version = version)
+
+        }
+
+          # browser()
+      } else if (df_name %in% c("fusions", "mutations_extended") &&
+        !is.null(pluck(data_synapse[[x]], df_name))) {
+        dplyr::inner_join(
+          pluck(data_synapse[[x]], df_name),
+          pluck(data_synapse[[x]], "cpt") %>%
+            dplyr::select("cohort", "cpt_genie_sample_id") %>%
+            distinct(),
+          by = c("Tumor_Sample_Barcode" = "cpt_genie_sample_id")
+        ) %>%
+          dplyr::mutate(cohort = cohort,
+                        version = version)
+      } else if (df_name %in% c("sv") &&
+                 !is.null(pluck(data_synapse[[x]], df_name))) {
+        # get list of IDs to keep
+        cpt_barcode_keep <- pluck(data_synapse[[x]], "cpt") %>%
+          mutate(
+            Tumor_Sample_Barcode =
+              stringr::str_replace_all(.data$cpt_genie_sample_id,
+                                       pattern = "-",
+                                       replacement = "\\."
+              )
+          ) %>%
+          pull("Tumor_Sample_Barcode")
+
+        # subset to those IDs
+        dplyr::inner_join(
+          pluck(data_synapse[[x]], df_name),
+          pluck(data_synapse[[x]], "cpt") %>%
+            dplyr::select("cohort", "cpt_genie_sample_id") %>%
+            distinct(),
+          by = c("Sample_Id" = "cpt_genie_sample_id")
+        ) %>%
+          dplyr::mutate(cohort = cohort,
+                        version = version)
+      }
+    })
+  })
+
+  # name each cohort
+  names(subset_all_dfs) <- unlist(cohort_temp)
+} # end of if statement for processing cohort only if patients met cancer
+  # diagnosis dataset inclusion criteria
+
+  # if 0 patients are returned for any cancer cohort, print a message and
+  # proceed with processing
+  # create vector to store indexes of cohorts with zero records
+  zero_pts_returned <- purrr::map(cohort_ca_dx, ~ nrow(.) == 0)
+
+  # print message
+  if (TRUE %in% zero_pts_returned) {
+    message_coh <- cohort_temp[unlist(zero_pts_returned)] %>%
+      unlist() %>%
+      paste(sep = "/")
+
+    message(paste0(
+      "No patients meeting the specified criteria were returned for the ",
+      message_coh, " cohort(s). Ensure that all parameters were correctly specified and check the raw data returned by the pull_data_synapse() call to ensure that there are patients that met the specified criteria (e.g., that there were patients with the specified combination of cancer type, institution, histology, stage, etc.). Additionally, the list of acceptable drugs can be found in the `drug_regimen_list` dataset available within this package. Note that drug names may vary across cancer cohorts and data releases."
+    ))
+  } else {
+  # apply names to objects that are part of subset_all_dfs
+  # rename ca_dx_index to ca_dx (cohort prefix added for all dfs below)
+  for (i in seq_along(subset_all_dfs)) {
+    names(subset_all_dfs[[i]]) <- str_replace_all(string = names(data_synapse[[i]]),
+                                                  pattern = c("ca_dx_index" = "ca_dx"))
+  }
+
+  # combine datasets across cancer cohorts
+  # for variables with conflicting data types, convert to character
+  # get list of all datasets included across cancer cohorts
+  df_list_pan_can <- unique(purrr::simplify(purrr::map(subset_all_dfs, names)))
+
+  # for each dataframe included across cancer cohorts
+  # obtain the corresponding dataframe for each particular cancer type
+  # some variables are different data types across data releases, make character
+  # to allow them to be set together
+  data_return <- map(df_list_pan_can, function(name_df){
+    map(subset_all_dfs, pluck, name_df) %>%
+      purrr::compact() %>%
+      list_flatten() %>%
+      map(., ~mutate(.x,
+                     across(any_of(c("release_version",
+                                     "naaccr_laterality_cd",
+                                     "naaccr_tnm_path_desc",
+                                     "pdl1_iclrange",
+                                     "pdl1_iclrange_2",
+                                     "pdl1_icurange",
+                                     "pdl1_icurange_2",
+                                     "pdl1_tcurange",
+                                     "pdl1_lcpsrange",
+                                     "pdl1_ucpsrange",
+                                     "cpt_seq_date",
+                                     "Match_Norm_Seq_Allele1",
+                                     "Match_Norm_Seq_Allele2",
+                                     "Protein_position")), ~as.character(.)))) %>%
+      bind_rows()
+  }
   )
 
-  # non-index cancer
-  cohort_ca_dx_non_index <- dplyr::inner_join(cohort_ca_dx %>%
-    dplyr::select("cohort", "record_id"),
-  pluck(data_synapse, "ca_dx_non_index"),
-  by = c("cohort", "record_id")
-  )
+  # name datasets with "cohort_" + df name
+  # rename cpt to ngs
+  names(data_return) <- stringr::str_replace(
+    pattern = "cpt",
+    replacement = "ngs",
+    string = paste0("cohort_", str_remove(pattern = "cohort_",
+                                                     string = df_list_pan_can)))
 
-  # PRISSMM Path
-  cohort_prissmm_pathology <- dplyr::inner_join(cohort_ca_dx %>%
-    dplyr::select("cohort", "record_id"),
-  pluck(data_synapse, "prissmm_pathology"),
-  by = c("cohort", "record_id")
-  )
+  # warn if >1 data release per cohort
+  chk_n_release_coh <- data_return %>%
+    purrr::pluck("cohort_pt_char") %>%
+    dplyr::count(.data$cohort, .data$release_version) %>%
+    dplyr::count(.data$cohort) %>%
+    dplyr::filter(n > 1) %>%
+    pull(.data$cohort)
 
-  # PRISSMM Imaging
-  cohort_prissmm_imaging <- dplyr::inner_join(cohort_ca_dx %>%
-    dplyr::select("cohort", "record_id"),
-  pluck(data_synapse, "prissmm_imaging"),
-  by = c("cohort", "record_id")
-  )
-
-  # PRISSMM Med Onc
-  cohort_prissmm_md <- dplyr::inner_join(cohort_ca_dx %>%
-    dplyr::select("cohort", "record_id"),
-  pluck(data_synapse, "prissmm_md"),
-  by = c("cohort", "record_id")
-  )
-
-  # TM (if applicable)
-  if (!is.null(pluck(data_synapse, "tumor_marker"))) {
-    cohort_tumor_marker <- dplyr::inner_join(cohort_ca_dx %>%
-      dplyr::select("cohort", "record_id"),
-    pluck(data_synapse, "tumor_marker"),
-    by = c("cohort", "record_id")
-    )
+  if (length(chk_n_release_coh) > 1){
+    cli::cli_warn("When creating an analytic cohort, it is recommended to use the most recent data release(s). It is not advisable to base an analytic cohort on multiple data releases of the same cancer cohort ({.val {paste0(chk_n_release_coh, collapse = ', ')}}).")
   }
 
-  # RT (if applicable)
-  if (!is.null(pluck(data_synapse, "ca_radtx"))) {
-    cohort_ca_radtx <- dplyr::inner_join(cohort_ca_dx %>%
-                                               dplyr::select("cohort", "record_id", "ca_seq"),
-                                             pluck(data_synapse, "ca_radtx"),
-                                             by = c("cohort", "record_id", "ca_seq")
-    )
-  }
-
-  # cancer panel test information
-  # keep records based on record_id + cancer sequence of interest
-  cohort_ngs <- dplyr::inner_join(
-    cohort_ca_dx %>%
-      dplyr::select("cohort", "record_id", "ca_seq"),
-    pluck(data_synapse, "cpt"),
-    by = c("cohort", "record_id", "ca_seq")
-  ) %>%
-    distinct()
-
-  if(any(names(cohort_ngs) == "cpt_sample_type") &
-     !any(names(cohort_ngs) == "sample_type")){
-
-    cohort_ngs <- cohort_ngs %>%
-      dplyr::mutate(sample_type = case_when(
-        str_to_lower(.data$cpt_sample_type)
-        %in% c("1", "primary", "primary tumor") ~ "Primary tumor",
-        str_to_lower(.data$cpt_sample_type)
-        %in% c("2", "lymph node metastasis") ~ "Lymph node metastasis",
-        str_to_lower(.data$cpt_sample_type)
-        %in% c("3", "distant organ metastasis") ~ "Distant organ metastasis",
-        str_to_lower(.data$cpt_sample_type)
-        %in% c("4", "metastasis site unspecified", "metastatic recurrence") ~
-          "Metastasis site unspecified",
-        str_to_lower(.data$cpt_sample_type)
-        %in% c("5", "local recurrence") ~ "Local recurrence",
-        str_to_lower(.data$cpt_sample_type)
-        %in% c("6", "unspecified") ~ as.character(NA),
-        str_to_lower(.data$cpt_sample_type)
-        %in% c("7", "not applicable or hematologic malignancy") ~
-          "Not applicable or hematologic malignancy"
-      ))
-  }
-
-  # genomic sequencing information
-  if (!is.null(pluck(data_synapse, "fusions"))) {
-    cohort_fusions <- dplyr::inner_join(pluck(data_synapse, "fusions"),
-      cohort_ngs %>%
-        dplyr::select("cohort", "cpt_genie_sample_id"),
-      by = c("Tumor_Sample_Barcode" = "cpt_genie_sample_id")
-    )
-  }
-
-  if (!is.null(pluck(data_synapse, "sv"))) {
-    cohort_sv <- dplyr::inner_join(pluck(data_synapse, "sv"),
-                                        cohort_ngs %>%
-                                          dplyr::select("cohort", "cpt_genie_sample_id"),
-                                        by = c("Sample_Id" = "cpt_genie_sample_id")
-    )
-  }
-
-  if (!is.null(pluck(data_synapse, "mutations_extended"))) {
-    cohort_mutations_extended <- dplyr::inner_join(pluck(data_synapse,
-                                                         "mutations_extended"),
-      cohort_ngs %>%
-        dplyr::select("cohort", "cpt_genie_sample_id"),
-      by = c("Tumor_Sample_Barcode" = "cpt_genie_sample_id")
-    )
-  }
-
-  # cna file is 1 col / tumor sample barcode
-  if (!is.null(pluck(data_synapse, "cna"))) {
-    # get list of IDs to keep
-    cpt_barcode_keep <- pluck(data_synapse, "cpt") %>%
-      mutate(
-        Tumor_Sample_Barcode =
-          stringr::str_replace_all(.data$cpt_genie_sample_id,
-            pattern = "-",
-            replacement = "\\."
-          )
-      ) %>%
-      pull("Tumor_Sample_Barcode")
-
-    cohort_cna <- pluck(data_synapse, "cna") %>%
-      select("Hugo_Symbol", any_of(cpt_barcode_keep))
-  }
-
-  # if 0 patients are returned
-  if (nrow(cohort_ca_dx) == 0) {
-    message("No patients meeting the specified criteria were returned.
-            Ensure that all parameters were correctly specified. Specifically,
-            the list of acceptable drugs can be found in the
-            `drug_regimen_list` dataset available with this package.")
-  }
 
   # return a table 1 to describe the cancer cohort if the user specifies
-  if (nrow(cohort_ca_dx) > 0 && return_summary == TRUE) {
-
+  if (nrow(data_return %>% pluck("cohort_ca_dx")) > 0 && return_summary == TRUE) {
     # number of records per patient in the diagnosis dataset
-    n_rec_dx_dset <- cohort_ca_dx %>%
+    n_rec_dx_dset <- data_return %>%
+      pluck("cohort_ca_dx") %>%
       dplyr::group_by(.data$record_id) %>%
       dplyr::summarize(n_rec_pt = n(), .groups = "drop") %>%
       gtsummary::tbl_summary(
@@ -848,7 +1074,8 @@ create_analytic_cohort <- function(data_synapse,
         quiet = TRUE
       )
 
-    n_rec_drugs_dset <- cohort_ca_drugs %>%
+    n_rec_drugs_dset <- data_return %>%
+      pluck("cohort_ca_drugs") %>%
       dplyr::group_by(.data$record_id) %>%
       dplyr::summarize(n_rec_pt = n(), .groups = "drop") %>%
       gtsummary::tbl_summary(
@@ -858,7 +1085,8 @@ create_analytic_cohort <- function(data_synapse,
         type = n_rec_pt ~ "categorical"
       )
 
-    n_rec_cpt_dset <- cohort_ngs %>%
+    n_rec_cpt_dset <- data_return %>%
+      pluck("cohort_ngs") %>%
       dplyr::group_by(.data$record_id) %>%
       dplyr::summarize(n_rec_pt = n(), .groups = "drop") %>%
       gtsummary::tbl_summary(
@@ -878,8 +1106,9 @@ create_analytic_cohort <- function(data_synapse,
     ) %>%
       gtsummary::bold_labels()
 
-    if (cohort_temp != "BrCa") {
-      tbl_cohort <- cohort_ca_dx %>%
+    if (!("BrCa" %in% cohort_temp)) {
+      tbl_cohort <- data_return %>%
+        pluck("cohort_ca_dx") %>%
         gtsummary::tbl_summary(
           include = c(
             "cohort", "institution",
@@ -900,13 +1129,17 @@ create_analytic_cohort <- function(data_synapse,
           quiet = TRUE
         )
     } else {
-      tbl_cohort <- cohort_ca_dx %>%
+      tbl_cohort <- data_return %>%
+        pluck("cohort_ca_dx") %>%
         # dplyr::group_by(.data$record_id) %>%
         # dplyr::mutate(n_rec_pt = n()) %>%
         # dplyr::ungroup() %>%
         gtsummary::tbl_summary(
-          include = c("cohort", "institution", "stage_dx",
-                             "ca_hist_brca"),
+          include = c(
+            "cohort", "institution", "stage_dx",
+            "ca_hist_adeno_squamous",
+            "ca_hist_brca"
+          ),
           label = list(
             cohort ~ "Cohort (cohort)",
             institution ~ "Institution (institution)",
@@ -923,7 +1156,8 @@ create_analytic_cohort <- function(data_synapse,
         )
     }
 
-    tbl_drugs <- cohort_ca_drugs %>%
+    tbl_drugs <- data_return %>%
+      pluck("cohort_ca_drugs") %>%
       gtsummary::tbl_summary(
         include = c("cohort", "institution", "regimen_drugs"),
         label = list(
@@ -940,10 +1174,13 @@ create_analytic_cohort <- function(data_synapse,
         quiet = TRUE
       )
 
-    tbl_ngs <- cohort_ngs %>%
+    tbl_ngs <- data_return %>%
+      pluck("cohort_ngs") %>%
       gtsummary::tbl_summary(
-        include = c("cohort", "institution",
-                           "cpt_oncotree_code", "cpt_seq_assay_id"),
+        include = c(
+          "cohort", "institution",
+          "cpt_oncotree_code", "cpt_seq_assay_id"
+        ),
         label = list(
           cohort ~ "Cohort (cohort)",
           institution ~ "Institution (institution)",
@@ -958,15 +1195,15 @@ create_analytic_cohort <- function(data_synapse,
         ),
         quiet = TRUE
       )
+
+    data_return$tbl_overall_summary <- tbl_overall_summary
+    data_return$tbl_cohort <- tbl_cohort
+    data_return$tbl_drugs <- tbl_drugs
+    data_return$tbl_ngs <- tbl_ngs
   }
 
   # drop variable before returning data frame
-  cohort_ca_dx <- cohort_ca_dx %>% select(-"index_ca_seq")
 
-  cohort_ca_drugs <- cohort_ca_drugs %>%
-    dplyr::select(-"order_within_cancer",
-                  -"order_within_regimen",
-                  -"abbreviation")
 
   # order of dataframes, should they exist
   df_order <- c(
@@ -976,25 +1213,21 @@ create_analytic_cohort <- function(data_synapse,
     "cohort_prissmm_imaging", "cohort_prissmm_pathology",
     "cohort_prissmm_md", "cohort_tumor_marker",
     "cohort_ngs",
-    "cohort_mutations_extended", "cohort_fusions", "cohort_sv", "cohort_cna",
+    "cohort_mutations_extended",
+    "cohort_fusions", "cohort_sv",
+    "cohort_cna",
     "tbl_overall_summary", "tbl_cohort", "tbl_drugs", "tbl_ngs"
   )
-
-  # return data frames & tables that are present in the function's environment
-  rtn <- mget(ls(environment(), pattern = "^cohort_|^tbl"),
-    envir = environment()
-  )
-
-
 
   # save elements on list in order that we want (clinical datasets, genomic
   # datasets, tables) and drop any items that don't appear in this run of
   # create_analytic_cohort
-  rtn_ordered <- rtn[c(df_order)] %>%
+  data_return <- data_return[c(df_order)] %>%
     purrr::compact()
 
 
-  if (nrow(cohort_ca_dx) > 0) {
-    return(rtn_ordered)
+  if (nrow(data_return$cohort_ca_dx) > 0) {
+    return(data_return)
   }
+  } # end of else statement to proceed when patients are returned that met the criteria
 } # end of function

--- a/tests/testthat/test-create_analytic_cohort.R
+++ b/tests/testthat/test-create_analytic_cohort.R
@@ -123,7 +123,26 @@ testthat::expect_true(
   set_synapse_credentials(pat = Sys.getenv("SYNAPSE_PAT"))
   data_releases_pull_data <- pmap(
       select(data_releases, cohort, version),
-        pull_data_synapse)
+        pull_data_synapse) %>%
+    # remove blank level from list
+    list_flatten() %>%
+    # change variable types to align with create_analytic_cohort updates
+    # that were required to stack data for multiple cohorts together
+    map_depth(., 2, ~mutate(.x,
+                   across(any_of(c("release_version",
+                                   "naaccr_laterality_cd",
+                                   "naaccr_tnm_path_desc",
+                                   "pdl1_iclrange",
+                                   "pdl1_iclrange_2",
+                                   "pdl1_icurange",
+                                   "pdl1_icurange_2",
+                                   "pdl1_tcurange",
+                                   "pdl1_lcpsrange",
+                                   "pdl1_ucpsrange",
+                                   "cpt_seq_date",
+                                   "Match_Norm_Seq_Allele1",
+                                   "Match_Norm_Seq_Allele2",
+                                   "Protein_position")), ~as.character(.))))
 
   # name the items in the list
   names(data_releases_pull_data) <- paste0(
@@ -138,39 +157,36 @@ testthat::expect_true(
 testthat::expect_true(
   if(.is_connected_to_genie(pat = Sys.getenv("SYNAPSE_PAT"))) {
 
-  # for each data release, run create analytic cohort
-  # get first object from each item in the list
-  # then run create analytic cohort
-  data_releases_create_cohort <- map(data_releases_pull_data, 1) %>%
-    map(., create_analytic_cohort)
-
-  # name the items in the list
-  names(data_releases_create_cohort) <- paste0(
-    data_releases$cohort, "_",
-    data_releases$version
-  )
+  # for each data release, run create analytic cohort via map
+  data_releases_create_cohort <- map(data_releases_pull_data,
+                                     create_analytic_cohort)
 
   # create analytic cohort with return summary = TRUE
-  data_releases_create_cohort_with_summary <- map(data_releases_pull_data, 1) %>%
-    map(., create_analytic_cohort, return_summary = TRUE)
-
-  # apply same names to list with summaries
-  names(data_releases_create_cohort_with_summary) <- paste0(
-    data_releases$cohort, "_",
-    data_releases$version
-  )
+  data_releases_create_cohort_with_summary <- map(data_releases_pull_data,
+                                                  create_analytic_cohort,
+                                                  return_summary = TRUE)
 
   length(data_releases_create_cohort_with_summary) > 0
 } else {0 == 0})
 
-# will update once we merge in PR to allow multiple cohorts in create_analytic_cohort
 test_that("multiple cohorts- argument check", {
   # exit if user doesn't have a synapse log in or access to data.
   testthat::skip_if_not(.is_connected_to_genie(pat = Sys.getenv("SYNAPSE_PAT")))
 
+  # wrong input specified
   expect_error(create_analytic_cohort(
-    data_synapse = data_releases_pull_data[1:2]
+    data_synapse = list(data_releases_pull_data[1:2],
+                        data_releases_pull_data[1:2])
   ))
+})
+
+test_that("multiple cohorts- check warning same cohort", {
+  # exit if user doesn't have a synapse log in or access to data.
+  testthat::skip_if_not(.is_connected_to_genie(pat = Sys.getenv("SYNAPSE_PAT")))
+
+  # create cohort for multiple data releases for the same cohort
+  expect_warning(create_analytic_cohort(data_releases_pull_data),
+                 "When creating an analytic cohort*")
 })
 
 test_that("non-existent data_synapse", {
@@ -222,22 +238,8 @@ test_that("correct cohort returned from create cohort", {
   # exit if user doesn't have a synapse log in or access to data.
   testthat::skip_if_not(.is_connected_to_genie(pat = Sys.getenv("SYNAPSE_PAT")))
 
-  # for each data frame returned with a cohort, get the cohort variable
-  # remove genomic data frames since we don't expect them to have a cohort variable
-  data_releases_create_cohort_no_genomic <- map(
-    data_releases_create_cohort,
-    ~ within(
-      .x,
-      rm(
-        cohort_cna,
-        cohort_fusions,
-        cohort_mutations_extended
-      )
-    )
-  )
-
   # for each dataframe returned for a data release, get the cohort variable
-  cohort_returned <- map_depth(data_releases_create_cohort_no_genomic, select, "cohort",
+  cohort_returned <- map_depth(data_releases_create_cohort, select, "cohort",
     .depth = 2
   ) %>%
     map(., bind_rows, .id = "df") %>%
@@ -263,21 +265,21 @@ test_that("check first index cancer default", {
   # incl criteria
 
   # for each index cancer dataset, pick the first index cancer
-  data_releases_create_cohort_ca_dx_index <- map_depth(data_releases_pull_data,
-    .depth = 2,
+  data_releases_create_cohort_ca_dx_index <- map(data_releases_pull_data,
+    # .depth = 2,
     pluck,
     "ca_dx_index"
   ) %>%
-    map_depth(., .depth = 2, group_by, cohort, record_id) %>%
-    map_depth(., .depth = 2, slice_min, ca_seq) %>%
-    map_depth(., .depth = 2, ungroup) %>%
-    map(., 1)
+    map(., group_by, cohort, record_id) %>%
+    map(., slice_min, ca_seq) %>%
+    map(., ungroup)
 
   # expect the default from create cohort to match the first index cancer
   # check that the first index cancer diagnosis is returned by create analytic cohort
   map2(
     data_releases_create_cohort_ca_dx_index,
-    map(data_releases_create_cohort, "cohort_ca_dx"),
+    map(data_releases_create_cohort, "cohort_ca_dx") %>%
+      map(., select, -version),
     expect_equal
   )
 })
@@ -292,12 +294,14 @@ test_that("index_ca_seq", {
   # if patient only has 1 index cancer, it should be returned
   # if patient has 2+ index cancers, the first two should be returned
   test_1a <- create_analytic_cohort(
-    data_synapse = data_releases_pull_data$`NSCLC_v2.0-public`$NSCLC_v2.0,
+    data_synapse = data_releases_pull_data$`NSCLC_v2.0-public`,
     index_ca_seq = c(1, 2),
-    return_summary = TRUE
-  )
+    return_summary = FALSE
+  ) %>%
+    # remove version variable since it won't be on data pulled from synapse
+    map(., select, -version)
 
-  test_1b <- data_releases_pull_data$`NSCLC_v2.0-public`$NSCLC_v2.0$ca_dx_index %>%
+  test_1b <- data_releases_pull_data$`NSCLC_v2.0-public`$ca_dx_index %>%
     group_by(cohort, record_id) %>%
     arrange(cohort, record_id, ca_seq) %>%
     mutate(index_ca_seq = 1:n()) %>%
@@ -310,13 +314,13 @@ test_that("index_ca_seq", {
 
   # an index cancer # that doesn't exist in the data is specified
   expect_error(create_analytic_cohort(
-    data_synapse = data_releases_pull_data$`NSCLC_v2.0-public`$NSCLC_v2.0,
+    data_synapse = data_releases_pull_data$`NSCLC_v2.0-public`,
     index_ca_seq = 100
   ))
 
   ## index cancer #s in cohort_ngs match those in cohort_ca_dx
   test2a <- create_analytic_cohort(
-    data_synapse = data_releases_pull_data$`CRC_v2.0-public`$CRC_v2.0,
+    data_synapse = data_releases_pull_data$`CRC_v2.0-public`,
     index_ca_seq = c(1, 2)
   )
 
@@ -338,11 +342,12 @@ test_that("institution", {
   # institution will be available across data releases,
   # don't need to test on each
   test_1a <- create_analytic_cohort(
-    data_synapse = data_releases_pull_data$`NSCLC_v2.0-public`$NSCLC_v2.0,
+    data_synapse = data_releases_pull_data$`NSCLC_v2.0-public`,
     institution = "dfci"
-  )
+  ) %>%
+    map(., select, -version)
 
-  test_1b <- data_releases_pull_data$`NSCLC_v2.0-public`$NSCLC_v2.0$ca_dx_index %>%
+  test_1b <- data_releases_pull_data$`NSCLC_v2.0-public`$ca_dx_index %>%
     group_by(cohort, record_id) %>%
     slice(which.min(ca_seq)) %>%
     ungroup() %>%
@@ -353,11 +358,12 @@ test_that("institution", {
 
   # multiple institutions specified
   test_2a <- create_analytic_cohort(
-    data_synapse = data_releases_pull_data$`BrCa_v1.1-consortium`$BrCa_v1.1,
+    data_synapse = data_releases_pull_data$`BrCa_v1.1-consortium`,
     institution = c("dfci", "msk")
-  )
+  ) %>%
+    map(., select, -version)
 
-  test_2b <- data_releases_pull_data$`BrCa_v1.1-consortium`$BrCa_v1.1$ca_dx_index %>%
+  test_2b <- data_releases_pull_data$`BrCa_v1.1-consortium`$ca_dx_index %>%
     group_by(cohort, record_id) %>%
     slice(which.min(ca_seq)) %>%
     ungroup() %>%
@@ -367,13 +373,13 @@ test_that("institution", {
 
   # a non-existent institution is specified
   expect_error(create_analytic_cohort(
-    data_synapse = data_releases_pull_data$`NSCLC_v2.0-public`$NSCLC_v2.0,
+    data_synapse = data_releases_pull_data$`NSCLC_v2.0-public`,
     institution = "uDFCI"
   ))
 
   # UHN didn't participate in CRC
   expect_error(create_analytic_cohort(
-    data_synapse = data_releases_pull_data$`CRC_v2.0-public`$CRC_v2.0,
+    data_synapse = data_releases_pull_data$`CRC_v2.0-public`,
     institution = "UHN"
   ))
 })
@@ -386,11 +392,12 @@ test_that("stage_dx", {
   # not cohort specific, all cohorts will have stage
   # test only on one cohort for now
   test_1a <- create_analytic_cohort(
-    data_synapse = data_releases_pull_data$`NSCLC_v2.0-public`$NSCLC_v2.0,
+    data_synapse = data_releases_pull_data$`NSCLC_v2.0-public`,
     stage_dx = "stage ii"
-  )
+  ) %>%
+    map(., select, -version)
 
-  test_1b <- data_releases_pull_data$`NSCLC_v2.0-public`$NSCLC_v2.0$ca_dx_index %>%
+  test_1b <- data_releases_pull_data$`NSCLC_v2.0-public`$ca_dx_index %>%
     group_by(cohort, record_id) %>%
     slice(which.min(ca_seq)) %>%
     ungroup() %>%
@@ -400,11 +407,12 @@ test_that("stage_dx", {
 
   # multiple stage values are specified
   test_2a <- create_analytic_cohort(
-    data_synapse = data_releases_pull_data$`NSCLC_v2.0-public`$NSCLC_v2.0,
+    data_synapse = data_releases_pull_data$`NSCLC_v2.0-public`,
     stage_dx = c("Stage I", "stage ii")
-  )
+  ) %>%
+    map(., select, -version)
 
-  test_2b <- data_releases_pull_data$`NSCLC_v2.0-public`$NSCLC_v2.0$ca_dx_index %>%
+  test_2b <- data_releases_pull_data$`NSCLC_v2.0-public`$ca_dx_index %>%
     group_by(cohort, record_id) %>%
     slice(which.min(ca_seq)) %>%
     ungroup() %>%
@@ -414,7 +422,7 @@ test_that("stage_dx", {
 
   # non-existent stage is specified
   expect_error(create_analytic_cohort(
-    data_synapse = data_releases_pull_data$`NSCLC_v2.0-public`$NSCLC_v2.0,
+    data_synapse = data_releases_pull_data$`NSCLC_v2.0-public`,
     stage_dx = "3A"
   ))
 })
@@ -424,23 +432,25 @@ test_that("histology", {
   testthat::skip_if_not(.is_connected_to_genie(pat = Sys.getenv("SYNAPSE_PAT")))
 
   # no histology is specified, all are returned
-  test0b <- data_releases_pull_data$`NSCLC_v2.0-public`$NSCLC_v2.0$ca_dx_index %>%
+  test0b <- data_releases_pull_data$`NSCLC_v2.0-public`$ca_dx_index %>%
     group_by(cohort, record_id) %>%
     slice(which.min(ca_seq)) %>%
     ungroup()
 
   expect_equal(
-    data_releases_create_cohort$`NSCLC_v2.0-public`$cohort_ca_dx,
+    data_releases_create_cohort$`NSCLC_v2.0-public`$cohort_ca_dx %>%
+      select(-version),
     test0b
   )
 
   # histology is specified and correct histology is returned
   test_1a <- create_analytic_cohort(
-    data_synapse = data_releases_pull_data$`NSCLC_v2.0-public`$NSCLC_v2.0,
+    data_synapse = data_releases_pull_data$`NSCLC_v2.0-public`,
     histology = "adenocarcinoma"
-  )
+  ) %>%
+    map(., select, -version)
 
-  test_1b <- data_releases_pull_data$`NSCLC_v2.0-public`$NSCLC_v2.0$ca_dx_index %>%
+  test_1b <- data_releases_pull_data$`NSCLC_v2.0-public`$ca_dx_index %>%
     group_by(cohort, record_id) %>%
     slice(which.min(ca_seq)) %>%
     ungroup() %>%
@@ -450,11 +460,12 @@ test_that("histology", {
 
   # repeat for BrCa, which has specific histologies available
   test_1c <- create_analytic_cohort(
-    data_synapse = data_releases_pull_data$`BrCa_v1.1-consortium`$BrCa_v1.1,
+    data_synapse = data_releases_pull_data$`BrCa_v1.1-consortium`,
     histology = "invasive ductal carcinoma"
-  )
+  ) %>%
+    map(., select, -version)
 
-  test_1d <- data_releases_pull_data$`BrCa_v1.1-consortium`$BrCa_v1.1$ca_dx_index %>%
+  test_1d <- data_releases_pull_data$`BrCa_v1.1-consortium`$ca_dx_index %>%
     group_by(cohort, record_id) %>%
     slice(which.min(ca_seq)) %>%
     ungroup() %>%
@@ -464,11 +475,12 @@ test_that("histology", {
 
   # multiple histologies are specified and returned
   test_2a <- create_analytic_cohort(
-    data_synapse = data_releases_pull_data$`NSCLC_v2.0-public`$NSCLC_v2.0,
+    data_synapse = data_releases_pull_data$`NSCLC_v2.0-public`,
     histology = c("adenocarcinoma", "squamous cell")
-  )
+  ) %>%
+    map(., select, -version)
 
-  test_2b <- data_releases_pull_data$`NSCLC_v2.0-public`$NSCLC_v2.0$ca_dx_index %>%
+  test_2b <- data_releases_pull_data$`NSCLC_v2.0-public`$ca_dx_index %>%
     group_by(cohort, record_id) %>%
     slice(which.min(ca_seq)) %>%
     ungroup() %>%
@@ -478,12 +490,12 @@ test_that("histology", {
 
   # a non-existent histology is specified
   expect_error(create_analytic_cohort(
-    data_synapse = data_releases_pull_data$`NSCLC_v2.0-public`$NSCLC_v2.0,
+    data_synapse = data_releases_pull_data$`NSCLC_v2.0-public`,
     histology = "squamous_adeno"
   ))
 
   expect_error(create_analytic_cohort(
-    data_synapse = data_releases_pull_data$`BrCa_v1.2-consortium`$BrCa_v1.2,
+    data_synapse = data_releases_pull_data$`BrCa_v1.2-consortium`,
     histology = "squamous_adeno"
   ))
 })
@@ -495,17 +507,18 @@ test_that("no regimen specified", {
   # all regimens are returned
   # should match all regimens given for a patients first index cancer
   test_1b <- inner_join(
-    data_releases_pull_data$`NSCLC_v2.0-public`$NSCLC_v2.0$ca_dx_index %>%
+    data_releases_pull_data$`NSCLC_v2.0-public`$ca_dx_index %>%
       group_by(record_id) %>%
       slice(which.min(ca_seq)) %>%
       ungroup() %>%
       select(cohort, record_id, ca_seq),
-    data_releases_pull_data$`NSCLC_v2.0-public`$NSCLC_v2.0$ca_drugs,
+    data_releases_pull_data$`NSCLC_v2.0-public`$ca_drugs,
     by = c("cohort", "record_id", "ca_seq")
   )
 
   expect_equal(
-    data_releases_create_cohort$`NSCLC_v2.0-public`$cohort_ca_drugs,
+    data_releases_create_cohort$`NSCLC_v2.0-public`$cohort_ca_drugs %>%
+      select(-version),
     test_1b
   )
 })
@@ -516,19 +529,20 @@ test_that("drug regimen specified, order not specified", {
 
   # one drug regimen specified, but order not specified
   test_1a <- create_analytic_cohort(
-    data_synapse = data_releases_pull_data$`NSCLC_v2.0-public`$NSCLC_v2.0,
+    data_synapse = data_releases_pull_data$`NSCLC_v2.0-public`,
     regimen_drugs = c("Carboplatin, Pemetrexed Disodium")
-  )
+  ) %>%
+    map(., select, -version)
 
   # expect all times that drug was received (for the first index ca)
   # to be returned
   test_1b <- left_join(
-    data_releases_pull_data$`NSCLC_v2.0-public`$NSCLC_v2.0$ca_dx_index %>%
+    data_releases_pull_data$`NSCLC_v2.0-public`$ca_dx_index %>%
       group_by(record_id) %>%
       slice(which.min(ca_seq)) %>%
       ungroup() %>%
       select(cohort, record_id, ca_seq),
-    data_releases_pull_data$`NSCLC_v2.0-public`$NSCLC_v2.0$ca_drugs,
+    data_releases_pull_data$`NSCLC_v2.0-public`$ca_drugs,
     by = c(
       "cohort", "record_id", "ca_seq"
     ),
@@ -541,9 +555,10 @@ test_that("drug regimen specified, order not specified", {
   # one drug regimen specified with drugs out of ABC order and in mixed case
   # regimen order not specified
   test_2a <- create_analytic_cohort(
-    data_synapse = data_releases_pull_data$`NSCLC_v2.0-public`$NSCLC_v2.0,
+    data_synapse = data_releases_pull_data$`NSCLC_v2.0-public`,
     regimen_drugs = c("Pemetrexed DISODIUM, carboplatin")
-  )
+  ) %>%
+    map(., select, -version)
 
   # expect all times that drug was received (for the first index ca)
   # to be returned
@@ -553,19 +568,20 @@ test_that("drug regimen specified, order not specified", {
 
   # multiple drug regimens specified, but order not specified
   test_3a <- create_analytic_cohort(
-    data_synapse = data_releases_pull_data$`NSCLC_v2.0-public`$NSCLC_v2.0,
+    data_synapse = data_releases_pull_data$`NSCLC_v2.0-public`,
     regimen_drugs = c("Carboplatin, Pemetrexed Disodium", "Nivolumab")
-  )
+  ) %>%
+    map(., select, -version)
 
   # expect all times that drug was received (for the first index ca)
   # to be returned
   test_3b <- left_join(
-    data_releases_pull_data$`NSCLC_v2.0-public`$NSCLC_v2.0$ca_dx_index %>%
+    data_releases_pull_data$`NSCLC_v2.0-public`$ca_dx_index %>%
       group_by(record_id) %>%
       slice(which.min(ca_seq)) %>%
       ungroup() %>%
       select(cohort, record_id, ca_seq),
-    data_releases_pull_data$`NSCLC_v2.0-public`$NSCLC_v2.0$ca_drugs,
+    data_releases_pull_data$`NSCLC_v2.0-public`$ca_drugs,
     by = c(
       "cohort", "record_id", "ca_seq"
     ),
@@ -580,20 +596,21 @@ test_that("drug regimen specified, order not specified", {
 
   # multiple drug regimens specified, regimen_type = containing
   test_4a <- create_analytic_cohort(
-    data_synapse = data_releases_pull_data$`NSCLC_v2.0-public`$NSCLC_v2.0,
+    data_synapse = data_releases_pull_data$`NSCLC_v2.0-public`,
     regimen_drugs = c("Carboplatin", "Nivolumab"),
     regimen_type = "containING"
-  )
+  ) %>%
+    map(., select, -version)
 
   # expect all times that drug was received (for the first index ca)
   # to be returned
   test_4b <- left_join(
-    data_releases_pull_data$`NSCLC_v2.0-public`$NSCLC_v2.0$ca_dx_index %>%
+    data_releases_pull_data$`NSCLC_v2.0-public`$ca_dx_index %>%
       group_by(record_id) %>%
       slice(which.min(ca_seq)) %>%
       ungroup() %>%
       select(cohort, record_id, ca_seq),
-    data_releases_pull_data$`NSCLC_v2.0-public`$NSCLC_v2.0$ca_drugs,
+    data_releases_pull_data$`NSCLC_v2.0-public`$ca_drugs,
     by = c(
       "cohort", "record_id", "ca_seq"
     ),
@@ -612,18 +629,19 @@ test_that("drug regimen specified, order specified to be within cancer", {
   # regimen of a certain number but drug name not specified
   # all patients whose first drug after diagnosis was carbo pem
   test_0a <- create_analytic_cohort(
-    data_synapse = data_releases_pull_data$`NSCLC_v2.0-public`$NSCLC_v2.0,
+    data_synapse = data_releases_pull_data$`NSCLC_v2.0-public`,
     regimen_order = 1,
     regimen_order_type = "within cancer"
-  )
+  ) %>%
+    map(., select, -version)
 
   # compare to data
   test_0b <- left_join(
-    data_releases_pull_data$`NSCLC_v2.0-public`$NSCLC_v2.0$ca_dx_index %>%
+    data_releases_pull_data$`NSCLC_v2.0-public`$ca_dx_index %>%
       group_by(record_id) %>%
       slice(which.min(ca_seq)) %>%
       select(cohort, record_id, ca_seq),
-    data_releases_pull_data$`NSCLC_v2.0-public`$NSCLC_v2.0$ca_drugs,
+    data_releases_pull_data$`NSCLC_v2.0-public`$ca_drugs,
     by = c("cohort", "record_id", "ca_seq"),
     multiple = "all"
   ) %>%
@@ -635,20 +653,21 @@ test_that("drug regimen specified, order specified to be within cancer", {
 
   # all patients whose first drug after diagnosis was carbo pem
   test_1a <- create_analytic_cohort(
-    data_synapse = data_releases_pull_data$`NSCLC_v2.0-public`$NSCLC_v2.0,
+    data_synapse = data_releases_pull_data$`NSCLC_v2.0-public`,
     regimen_drugs = c("Carboplatin, Pemetrexed Disodium"),
     regimen_type = "Exact",
     regimen_order = 1,
     regimen_order_type = "within cancer"
-  )
+  ) %>%
+    map(., select, -version)
 
   # compare to data
   test_1b <- left_join(
-    data_releases_pull_data$`NSCLC_v2.0-public`$NSCLC_v2.0$ca_dx_index %>%
+    data_releases_pull_data$`NSCLC_v2.0-public`$ca_dx_index %>%
       group_by(record_id) %>%
       slice(which.min(ca_seq)) %>%
       select(cohort, record_id, ca_seq),
-    data_releases_pull_data$`NSCLC_v2.0-public`$NSCLC_v2.0$ca_drugs,
+    data_releases_pull_data$`NSCLC_v2.0-public`$ca_drugs,
     by = c("cohort", "record_id", "ca_seq"),
     multiple = "all"
   ) %>%
@@ -661,21 +680,22 @@ test_that("drug regimen specified, order specified to be within cancer", {
 
   # second regimen after diagnosis was carbo pem
   test_2a <- create_analytic_cohort(
-    data_synapse = data_releases_pull_data$`NSCLC_v2.0-public`$NSCLC_v2.0,
+    data_synapse = data_releases_pull_data$`NSCLC_v2.0-public`,
     regimen_drugs = c("Carboplatin, Pemetrexed Disodium"),
     regimen_type = "Exact",
     regimen_order = 2,
     regimen_order_type = "within cancer"
-  )
+  ) %>%
+    map(., select, -version)
 
   # compare to data
   test_2b <- left_join(
-    data_releases_pull_data$`NSCLC_v2.0-public`$NSCLC_v2.0$ca_dx_index %>%
+    data_releases_pull_data$`NSCLC_v2.0-public`$ca_dx_index %>%
       group_by(record_id) %>%
       slice(which.min(ca_seq)) %>%
       ungroup() %>%
       select(cohort, record_id, ca_seq),
-    data_releases_pull_data$`NSCLC_v2.0-public`$NSCLC_v2.0$ca_drugs,
+    data_releases_pull_data$`NSCLC_v2.0-public`$ca_drugs,
     by = c(
       "cohort", "record_id", "ca_seq"
     ),
@@ -692,21 +712,22 @@ test_that("drug regimen specified, order specified to be within cancer", {
 
   # first AND/OR second regimen after diagnosis was carbo pem
   test_3a <- create_analytic_cohort(
-    data_synapse = data_releases_pull_data$`NSCLC_v2.0-public`$NSCLC_v2.0,
+    data_synapse = data_releases_pull_data$`NSCLC_v2.0-public`,
     regimen_drugs = c("Carboplatin, Pemetrexed Disodium"),
     regimen_type = "Exact",
     regimen_order = c(1, 2),
     regimen_order_type = "within cancer"
-  )
+  ) %>%
+    map(., select, -version)
 
   # compare to data
   test_3b <- left_join(
-    data_releases_pull_data$`NSCLC_v2.0-public`$NSCLC_v2.0$ca_dx_index %>%
+    data_releases_pull_data$`NSCLC_v2.0-public`$ca_dx_index %>%
       group_by(record_id) %>%
       slice(which.min(ca_seq)) %>%
       ungroup() %>%
       select(cohort, record_id, ca_seq),
-    data_releases_pull_data$`NSCLC_v2.0-public`$NSCLC_v2.0$ca_drugs,
+    data_releases_pull_data$`NSCLC_v2.0-public`$ca_drugs,
     by = c(
       "cohort", "record_id", "ca_seq"
     ),
@@ -724,20 +745,21 @@ test_that("drug regimen specified, order specified to be within cancer", {
   # first AND/OR second regimen after diagnosis was carbo pem
   # regimen_type = containing rather than default of exact
   test_4a <- create_analytic_cohort(
-    data_synapse = data_releases_pull_data$`NSCLC_v2.0-public`$NSCLC_v2.0,
+    data_synapse = data_releases_pull_data$`NSCLC_v2.0-public`,
     regimen_drugs = c("Carboplatin, Pemetrexed Disodium"),
     regimen_type = "containing",
     regimen_order = c(1, 2),
     regimen_order_type = "within cancer"
-  )
+  ) %>%
+    map(., select, -version)
 
   test_4b <- left_join(
-    data_releases_pull_data$`NSCLC_v2.0-public`$NSCLC_v2.0$ca_dx_index %>%
+    data_releases_pull_data$`NSCLC_v2.0-public`$ca_dx_index %>%
       group_by(record_id) %>%
       slice(which.min(ca_seq)) %>%
       ungroup() %>%
       select(cohort, record_id, ca_seq),
-    data_releases_pull_data$`NSCLC_v2.0-public`$NSCLC_v2.0$ca_drugs,
+    data_releases_pull_data$`NSCLC_v2.0-public`$ca_drugs,
     by = c(
       "cohort", "record_id", "ca_seq"
     ),
@@ -762,18 +784,19 @@ test_that("exact drug regimen specified,
   # single regimen specified, want first time that regimen
   # was given for all cancers
   test_1a <- create_analytic_cohort(
-    data_synapse = data_releases_pull_data$`NSCLC_v2.0-public`$NSCLC_v2.0,
+    data_synapse = data_releases_pull_data$`NSCLC_v2.0-public`,
     regimen_drugs = c("Carboplatin, Pemetrexed Disodium"),
     regimen_order = c(1),
     regimen_order_type = "within REGimen"
-  )
+  ) %>%
+    map(., select, -version)
 
   test_1b <- left_join(
-    data_releases_pull_data$`NSCLC_v2.0-public`$NSCLC_v2.0$ca_dx_index %>%
+    data_releases_pull_data$`NSCLC_v2.0-public`$ca_dx_index %>%
       group_by(record_id) %>%
       slice(which.min(ca_seq)) %>%
       select(cohort, record_id, ca_seq),
-    data_releases_pull_data$`NSCLC_v2.0-public`$NSCLC_v2.0$ca_drugs,
+    data_releases_pull_data$`NSCLC_v2.0-public`$ca_drugs,
     by = c(
       "cohort", "record_id", "ca_seq"
     ),
@@ -790,18 +813,19 @@ test_that("exact drug regimen specified,
 
   # multiple regimens specified, want first time each given
   test_2a <- create_analytic_cohort(
-    data_synapse = data_releases_pull_data$`NSCLC_v2.0-public`$NSCLC_v2.0,
+    data_synapse = data_releases_pull_data$`NSCLC_v2.0-public`,
     regimen_drugs = c("Carboplatin, Pemetrexed Disodium", "Nivolumab"),
     regimen_order = c(1),
     regimen_order_type = "within REGimen"
-  )
+  ) %>%
+    map(., select, -version)
 
   test_2b <- left_join(
-    data_releases_pull_data$`NSCLC_v2.0-public`$NSCLC_v2.0$ca_dx_index %>%
+    data_releases_pull_data$`NSCLC_v2.0-public`$ca_dx_index %>%
       group_by(record_id) %>%
       slice(which.min(ca_seq)) %>%
       select(cohort, record_id, ca_seq),
-    data_releases_pull_data$`NSCLC_v2.0-public`$NSCLC_v2.0$ca_drugs,
+    data_releases_pull_data$`NSCLC_v2.0-public`$ca_drugs,
     by = c(
       "cohort", "record_id", "ca_seq"
     ),
@@ -823,18 +847,19 @@ test_that("exact drug regimen specified,
   # first and/or second time they were received
   # multiple regimens specified, want first time each given
   test_3a <- create_analytic_cohort(
-    data_synapse = data_releases_pull_data$`NSCLC_v2.0-public`$NSCLC_v2.0,
+    data_synapse = data_releases_pull_data$`NSCLC_v2.0-public`,
     regimen_drugs = c("Carboplatin, Pemetrexed Disodium", "Nivolumab"),
     regimen_order = c(1, 2),
     regimen_order_type = "within REGimen"
-  )
+  ) %>%
+    map(., select, -version)
 
   test_3b <- left_join(
-    data_releases_pull_data$`NSCLC_v2.0-public`$NSCLC_v2.0$ca_dx_index %>%
+    data_releases_pull_data$`NSCLC_v2.0-public`$ca_dx_index %>%
       group_by(record_id) %>%
       slice(which.min(ca_seq)) %>%
       select(cohort, record_id, ca_seq),
-    data_releases_pull_data$`NSCLC_v2.0-public`$NSCLC_v2.0$ca_drugs,
+    data_releases_pull_data$`NSCLC_v2.0-public`$ca_drugs,
     by = c(
       "cohort", "record_id", "ca_seq"
     ),
@@ -861,15 +886,16 @@ test_that("containing drug regimen specified,
   # specify regimen type to be containing (default is exact,
   # which is what is implemented in the above)
   test_1c <- create_analytic_cohort(
-    data_synapse = data_releases_pull_data$`NSCLC_v2.0-public`$NSCLC_v2.0,
+    data_synapse = data_releases_pull_data$`NSCLC_v2.0-public`,
     regimen_drugs = c("Carboplatin, Pemetrexed Disodium"),
     regimen_type = "containing",
     regimen_order = c(1),
     regimen_order_type = "within REGimen"
-  )
+  ) %>%
+    map(., select, -version)
 
   # order containing
-  ordered_containing_regs <- data_releases_pull_data$`NSCLC_v2.0-public`$NSCLC_v2.0$ca_drugs %>%
+  ordered_containing_regs <- data_releases_pull_data$`NSCLC_v2.0-public`$ca_drugs %>%
     filter(grepl("Carboplatin, Pemetrexed Disodium", regimen_drugs)) %>%
     distinct(cohort, record_id, regimen_number, regimen_drugs) %>%
     group_by(cohort, record_id) %>%
@@ -883,7 +909,7 @@ test_that("containing drug regimen specified,
 
   # merge containing order onto the regimen data
   # only keep regimens of interest
-  ca_drugs_with_containing_order <- inner_join(data_releases_pull_data$`NSCLC_v2.0-public`$NSCLC_v2.0$ca_drugs,
+  ca_drugs_with_containing_order <- inner_join(data_releases_pull_data$`NSCLC_v2.0-public`$ca_drugs,
     ordered_containing_regs,
     by = c(
       "cohort", "record_id",
@@ -895,7 +921,7 @@ test_that("containing drug regimen specified,
   # merge cohort with patients who received drug regimens of interest
   # in order specified
   test_1d <- inner_join(
-    data_releases_pull_data$`NSCLC_v2.0-public`$NSCLC_v2.0$ca_dx_index %>%
+    data_releases_pull_data$`NSCLC_v2.0-public`$ca_dx_index %>%
       group_by(record_id) %>%
       slice(which.min(ca_seq)) %>%
       ungroup() %>%
@@ -931,7 +957,7 @@ test_that("regimen_type", {
   # only testing on a single cancer cohort since not cohort-specific
   # invalid value provided for regimen_type
   expect_error(create_analytic_cohort(
-    data_synapse = data_releases_pull_data$`NSCLC_v2.0-public`$NSCLC_v2.0,
+    data_synapse = data_releases_pull_data$`NSCLC_v2.0-public`,
     regimen_type = "exact_containing"
   ))
 
@@ -986,7 +1012,7 @@ test_that("No patients met criteria", {
   testthat::skip_if_not(.is_connected_to_genie(pat = Sys.getenv("SYNAPSE_PAT")))
 
   expect_message(create_analytic_cohort(
-    data_synapse = data_releases_pull_data$`NSCLC_v2.0-public`$NSCLC_v2.0,
+    data_synapse = data_releases_pull_data$`NSCLC_v2.0-public`,
     regimen_drugs = "Carboplatin, Pemetrexed",
     regimen_order = 1000,
     regimen_order_type = "within cancer"


### PR DESCRIPTION
This is a big one - happy to set up time to discuss these changes if that would be helpful. Not at all urgent, we can discuss at the spring hackathon if that's easier for both of you. Tagging you both as a reviewer since it would be great to get both of your feedback on some things, but no need for both to review in detail and we can make a game plan next time we chat. 

What changes are involved in this pull request? 
- Updated `create_analytic_cohort` to allow the function to take multiple cohorts from `pull_data_synapse()` and stack the data together. The update is based on modifying each data step to handle a list as opposed to a single dataset. After running each step of creating the cohort based on dx + drug information, the lists for each cohort are then stacked together into dfs. Alternatively, we could have stacked together and then maybe left the rest of the code mostly alone. Probably 6 one way half dozen the other, but if we would rather go the route of stacking first I can look into making the update. 
- This required coercing some variable types to character so that the data could be stacked together across releases
- Updated in a way that supports backwards compatibility with different ways that the data_synapse object could be supplied (e.g., data_synapse, data_synapse$COHORT_vX.X, or mapping over data_synapse to run `create_analytic_cohort`)

Would specifically like your thoughts on:
- To distinguish cohorts and data releases in the resulting datasets, I added a cohort and version variable to each file, including the mutations, CNA, and fusion/sv files. @karissawhiting Does this introduce any issues with downstream calls to gnomeR functions?
- Rather than stacking the data together for the user, we could potentially return nested lists and leave it to the user to aggregate the data. That felt like not a big enhancement compared to mapping over `create_analytic_cohort`, so I didn't go this route, but open to everyone's thoughts. We could also make whether to stack or not an input parameter w/ a default of either stack/don't stack. 
- I added a warning if the `data_synapse` object contains multiple data releases for the same cohort (e.g., NSCLC v1.0-public and v3.1-consortium; PR includes a unit test to check for this warning). Alternatively, we could return only the data corresponding to the latest release and include a message indicating that we have done so. 
- Hannah had added default of "NULL" for some of the input parameters. I don't know if there are benefits/drawbacks to doing this, so I left them there, but we can remove if needed. 

Is there a GitHub issue corresponding to this pull request? If so, please provide link. #112 

Checklist for PR Reviewer
- [ ] Make sure all updates from main branch are pulled to branch issuing pull request
- [ ] Confirm package dependencies are installed by running `renv::install()`
- [ ] For bug corrections, check that unit test was added
- [ ] Document changes from this pull request in `NEWS.md` file
- [ ] `devtools::spell_check()` runs with no spelling errors in documentation
- [ ] R CMD Check runs without errors, warnings, and notes
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website. If there are errors returned, try running `pkgdown::build_site(new_process = FALSE)` for better error messaging.
- [ ] Code coverage is suitable for any new functions/features. Review coverage with `covr::report()`. Before you run, begin in a fresh R session without any packages loaded and set `Sys.setenv(NOT_CRAN="true")`.
- [ ] Increment the version number using `usethis::use_version(which = "dev")`
- [ ] Approve and merge pull request
